### PR TITLE
manually call ondamage event when preliminary killing a mob

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/DamageEvent.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/DamageEvent.java
@@ -1,5 +1,6 @@
 package com.robertx22.mine_and_slash.uncommon.effectdatas;
 
+import com.robertx22.library_of_exile.events.base.ExileEvents;
 import com.robertx22.library_of_exile.main.Packets;
 import com.robertx22.library_of_exile.utils.SoundUtils;
 import com.robertx22.mine_and_slash.a_libraries.dmg_number_particle.particle.InteractionNotifier;
@@ -673,6 +674,7 @@ public class DamageEvent extends EffectEvent {
             target.setHealth(hp);
             // todo this might create bugs but its probably better that damage actually works..
             if (target.getHealth() <= 0) {
+                ExileEvents.DAMAGE_AFTER_CALC.callEvents(new ExileEvents.OnDamageEntity(dmgsource, vanillaDamage, target));
                 target.die(target.damageSources().mobAttack(this.source));
             }
             if (attackInfo != null) {

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/DamageEvent.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/DamageEvent.java
@@ -674,6 +674,7 @@ public class DamageEvent extends EffectEvent {
             target.setHealth(hp);
             // todo this might create bugs but its probably better that damage actually works..
             if (target.getHealth() <= 0) {
+                ExileEvents.DAMAGE_BEFORE_CALC.callEvents(new ExileEvents.OnDamageEntity(dmgsource, vanillaDamage, target));
                 ExileEvents.DAMAGE_AFTER_CALC.callEvents(new ExileEvents.OnDamageEntity(dmgsource, vanillaDamage, target));
                 target.die(target.damageSources().mobAttack(this.source));
             }


### PR DESCRIPTION
When I was researching issue with Blue Skies mobs not giving exp I noticed that sometimes mob dies before onDamageEvent being called.
In order for mob to give exp player damage should be registered with AntiMobFarm mod and if this step is missing then exp won't be given from the said mob.

Well, with this ugly fix I wasn't able to reproduce that issue no longer