### PR TITLE
Add support gems context to ailments init stage to set correct stats

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/capability/entity/EntityAilmentData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/capability/entity/EntityAilmentData.java
@@ -8,6 +8,7 @@ import com.robertx22.mine_and_slash.database.data.stats.types.ailment.AilmentDur
 import com.robertx22.mine_and_slash.database.data.stats.types.ailment.AilmentEffectStat;
 import com.robertx22.mine_and_slash.database.data.stats.types.ailment.AilmentResistance;
 import com.robertx22.mine_and_slash.database.registry.ExileDB;
+import com.robertx22.mine_and_slash.saveclasses.unit.Unit;
 import com.robertx22.mine_and_slash.uncommon.MathHelper;
 import com.robertx22.mine_and_slash.uncommon.datasaving.Load;
 import com.robertx22.mine_and_slash.uncommon.effectdatas.EventBuilder;
@@ -73,8 +74,7 @@ public class EntityAilmentData {
         }
     }
 
-    public void onAilmentCausingDamage(LivingEntity caster, LivingEntity target, Ailment ailment, float dmg) {
-
+    public void onAilmentCausingDamage(LivingEntity caster, LivingEntity target, Ailment ailment, float dmg, Unit unit) {
         if (!datas.containsKey(caster.getUUID())) {
             datas.put(caster.getUUID(), new OneData());
         }
@@ -85,11 +85,11 @@ public class EntityAilmentData {
         AilmentResistance res = new AilmentResistance(ailment);
         AilmentEffectStat eff = new AilmentEffectStat(ailment);
 
-        float speed = Load.Unit(caster).getUnit().getCalculatedStat(AilmentSpeed.INSTANCE).getMultiplier();
+        float speed = unit.getCalculatedStat(AilmentSpeed.INSTANCE).getMultiplier();
 
 
         dmg = dmg * ailment.damageEffectivenessMulti; // make sure this isnt done multiple times
-        dmg *= Load.Unit(caster).getUnit().getCalculatedStat(eff).getMultiplier();
+        dmg *= unit.getCalculatedStat(eff).getMultiplier();
 
         var resist = Load.Unit(target).getUnit().getCalculatedStat(res);
         float resmulti = resist.getReverseMultiplier();
@@ -107,9 +107,8 @@ public class EntityAilmentData {
 
 
             int ticks = ailment.durationTicks;
-            var stat = Load.Unit(caster).getUnit().getCalculatedStat(AilmentSpeed.INSTANCE).getMultiplier();
-            ticks /= stat;
-            ticks *= Load.Unit(caster).getUnit().getCalculatedStat(dur).getMultiplier();
+            ticks /= speed;
+            ticks *= unit.getCalculatedStat(dur).getMultiplier();
 
             if (ticks < 21) {
                 ticks = 21;
@@ -138,7 +137,7 @@ public class EntityAilmentData {
 
             float add = dmg / forFull;
             strength = MathHelper.clamp(data.strMap.get(ailment.GUID()) + (add), 0, 1);
-            strength *= Load.Unit(caster).getUnit().getCalculatedStat(eff).getMultiplier();
+            strength *= unit.getCalculatedStat(eff).getMultiplier();
             strength *= Load.Unit(target).getUnit().getCalculatedStat(res).getMultiplier();
 
             data.strMap.put(ailment.GUID(), strength);

--- a/src/main/java/com/robertx22/mine_and_slash/capability/player/PlayerData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/capability/player/PlayerData.java
@@ -9,14 +9,11 @@ import com.robertx22.mine_and_slash.a_libraries.curios.RefCurio;
 import com.robertx22.mine_and_slash.capability.DirtySync;
 import com.robertx22.mine_and_slash.capability.entity.SummonedData;
 import com.robertx22.mine_and_slash.capability.player.data.*;
-import com.robertx22.mine_and_slash.capability.player.data.JewelData;
 import com.robertx22.mine_and_slash.capability.player.helper.GemInventoryHelper;
-import com.robertx22.mine_and_slash.capability.player.helper.JewelInvHelper;
 import com.robertx22.mine_and_slash.capability.player.helper.MyInventory;
 import com.robertx22.mine_and_slash.characters.CharStorageData;
 import com.robertx22.mine_and_slash.database.data.omen.OmenData;
 import com.robertx22.mine_and_slash.database.data.spells.components.Spell;
-import com.robertx22.mine_and_slash.database.data.stats.types.JewelSocketStat;
 import com.robertx22.mine_and_slash.event_hooks.my_events.CachedPlayerStats;
 import com.robertx22.mine_and_slash.gui.screens.stat_gui.StatCalcInfoData;
 import com.robertx22.mine_and_slash.mmorpg.SlashRef;
@@ -26,7 +23,6 @@ import com.robertx22.mine_and_slash.saveclasses.spells.SpellCastingData;
 import com.robertx22.mine_and_slash.saveclasses.spells.SpellSchoolsData;
 import com.robertx22.mine_and_slash.saveclasses.unit.Unit;
 import com.robertx22.mine_and_slash.saveclasses.unit.stat_calc.StatCalculation;
-import com.robertx22.mine_and_slash.uncommon.datasaving.Load;
 import com.robertx22.mine_and_slash.uncommon.datasaving.StackSaving;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -260,20 +256,25 @@ public class PlayerData implements ICap {
         return null;
     }
 
-    public Unit getSpellUnitStats(Player p, Spell spell) {
-
+    public Unit getSpellUnitStats(Spell spell) {
         if (!spellUnits.containsKey(spell.GUID())) {
             int key = keyOf(spell);
             if (spell.config.usesSupportGemsFromAnotherSpell()) {
                 key = keyOf(spell.config.getSpellUsedForSuppGems());
             }
+
             var unit = calcSpellUnit(spell, key);
             spellUnits.put(spell.GUID(), unit);
         }
-        if (!spellUnits.containsKey(spell.GUID())) {
-            return Load.Unit(p).getUnit();
-        }
         return spellUnits.get(spell.GUID());
+    }
+
+    public boolean canHaveSpellUnit(Spell spell) {
+        int key = keyOf(spell);
+        if (spell.config.usesSupportGemsFromAnotherSpell()) {
+            key = keyOf(spell.config.getSpellUsedForSuppGems());
+        }
+        return key != SpellCastingData.SPELL_KEY_NOT_EXIST;
     }
 
     public void setSpellUnitsDirty() {

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/spell_classes/bases/SpellCastContext.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/spell_classes/bases/SpellCastContext.java
@@ -47,7 +47,7 @@ public class SpellCastContext {
 
         if (caster instanceof Player p) {
             try {
-                this.unit = Load.player(p).getSpellUnitStats(p, spell);
+                this.unit = Load.player(p).getSpellUnitStats(spell);
             } catch (Exception e) {
                 this.unit = this.data.getUnit();
             }

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/stats/types/ailment/AilmentChance.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/stats/types/ailment/AilmentChance.java
@@ -8,6 +8,7 @@ import com.robertx22.mine_and_slash.database.data.stats.StatGuiGroup;
 import com.robertx22.mine_and_slash.database.data.stats.effects.base.BaseDamageEffect;
 import com.robertx22.mine_and_slash.database.data.stats.priority.StatPriority;
 import com.robertx22.mine_and_slash.saveclasses.unit.StatData;
+import com.robertx22.mine_and_slash.saveclasses.unit.Unit;
 import com.robertx22.mine_and_slash.uncommon.datasaving.Load;
 import com.robertx22.mine_and_slash.uncommon.effectdatas.DamageEvent;
 import com.robertx22.mine_and_slash.uncommon.effectdatas.EventBuilder;
@@ -53,7 +54,8 @@ public class AilmentChance extends Stat {
         event.Activate();
         event.sendDamageMessage(event.calculateAllBonusElementalDamage());
 
-        Load.Unit(target).ailments.onAilmentCausingDamage(source, target, ailment, event.data.getNumber());
+        Unit unit = Load.getSpellUnit(source, spell);
+        Load.Unit(target).ailments.onAilmentCausingDamage(source, target, ailment, event.data.getNumber(), unit);
     }
 
     private class Effect extends BaseDamageEffect {

--- a/src/main/java/com/robertx22/mine_and_slash/saveclasses/spells/SpellCastingData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/saveclasses/spells/SpellCastingData.java
@@ -34,15 +34,11 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class SpellCastingData {
 
+    public static final int SPELL_KEY_NOT_EXIST = -1;
     public HashMap<Integer, String> hotbar = new HashMap<>();
 
 
@@ -69,7 +65,7 @@ public class SpellCastingData {
                 return en.getKey();
             }
         }
-        return -1;
+        return SPELL_KEY_NOT_EXIST;
     }
 
     public List<HotbarSpellData> getAllHotbarSpellsInfo() {

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/datasaving/Load.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/datasaving/Load.java
@@ -5,7 +5,9 @@ import com.robertx22.mine_and_slash.capability.entity.EntityData;
 import com.robertx22.mine_and_slash.capability.player.PlayerBackpackData;
 import com.robertx22.mine_and_slash.capability.player.PlayerData;
 import com.robertx22.mine_and_slash.capability.world.WorldData;
+import com.robertx22.mine_and_slash.database.data.spells.components.Spell;
 import com.robertx22.mine_and_slash.maps.MapData;
+import com.robertx22.mine_and_slash.saveclasses.unit.Unit;
 import com.robertx22.mine_and_slash.uncommon.utilityclasses.WorldUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
@@ -18,6 +20,13 @@ public class Load {
 
     // todo give a blank one for mobs
 
+    public static Unit getSpellUnit(Entity entity, Spell spell) {
+        if (spell != null && entity instanceof Player p && player(p).canHaveSpellUnit(spell)) {
+            return player(p).getSpellUnitStats(spell);
+        }
+
+        return Unit(entity).getUnit();
+    }
 
     public static EntityData Unit(Entity entity) {
         return entity.getCapability(EntityData.INSTANCE).orElse(new EntityData((LivingEntity) entity));

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/EffectEvent.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/EffectEvent.java
@@ -321,7 +321,7 @@ public abstract class EffectEvent implements IGUID {
             if (isSpell()) {
                 if (en instanceof Player p) {
                     if (getSpell() != null) {
-                        un = Load.player(p).getSpellUnitStats(p, getSpell());
+                        un = Load.player(p).getSpellUnitStats(getSpell());
                     }
                 }
             }

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/stat_calculation/MobStatUtils.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/stat_calculation/MobStatUtils.java
@@ -42,7 +42,7 @@ public class MobStatUtils {
 
         if (caster instanceof Player player) {
             var spell = Load.Unit(en).summonedPetData.getSourceSpell();
-            var data = Load.player(player).getSpellUnitStats(player, spell);
+            var data = Load.player(player).getSpellUnitStats(spell);
 
             for (Map.Entry<String, StatData> e : data.getStats().stats.entrySet()) {
                 if (e.getValue().GetStat() instanceof SummonStat sstat) {


### PR DESCRIPTION
Following Robert's hint to add spell context to ailments that can affect primarily ailment duration
https://discord.com/channels/726729169999888495/1402339624818315354

Currently, we have only Swift Afflication support gem that changes poison_duration if you want to test this