### PR TITLE
Restore health bar icons

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/a_libraries/neat/HealthBarRenderer.java
+++ b/src/main/java/com/robertx22/mine_and_slash/a_libraries/neat/HealthBarRenderer.java
@@ -212,7 +212,7 @@ public class HealthBarRenderer {
                     .map(x -> Pair.of(EffectIcon.of(ExileDB.ExileEffects().get(x.getKey()).getTexture(), x.getValue().stacks), x.getValue().ticks_left))
                     .sorted((x, y) -> -Integer.compare(x.getValue(), y.getValue()))
                     .map(Pair::getLeft)
-                    .filter(x -> x.location() == null)
+                    .filter(x -> x.location() != null)
                     .collect(Collectors.toCollection(ArrayList::new));
         }
         return Collections.EMPTY_LIST;


### PR DESCRIPTION
I was testing ailments and noticed there are no status icons on mobs.
With this I atleast was able to show curse icons