### PR TITLE
Recalculate xp for each level

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/saveclasses/prof_tool/ProfessionToolData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/saveclasses/prof_tool/ProfessionToolData.java
@@ -81,11 +81,10 @@ public class ProfessionToolData implements ITooltip {
     }
 
     public void addExp(Player p, ItemStack stack, int added) {
-
         xp += added;
 
-        int currentXPNeeded = getExpNeeded();
         if (lvl < GameBalanceConfig.get().MAX_LEVEL) {
+            int currentXPNeeded = getExpNeeded();
             while (xp >= currentXPNeeded) {
 
                 if (lvl >= GameBalanceConfig.get().MAX_LEVEL) {
@@ -104,6 +103,8 @@ public class ProfessionToolData implements ITooltip {
                     addStat();
                     p.sendSystemMessage(Chats.TOOL_ADD_STAT.locName(stack.getHoverName(), getRarity().locName()).withStyle(getRarity().textFormatting()));
                 }
+
+                currentXPNeeded = getExpNeeded();
             }
         }
     }


### PR DESCRIPTION
Fix for profession powerleveling abuse - https://discord.com/channels/726729169999888495/1412886508624416818

We have to recalculate required xp for the next level because there are some significant calculations there