### PR TITLE
New projectile trajectory parameters

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/ProjectileCastHelper.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/ProjectileCastHelper.java
@@ -90,6 +90,9 @@ public class ProjectileCastHelper {
             }
 
             baseDirection = positionToVelocity(new MyPosition(pos), new MyPosition(target.getEyePosition()));
+
+            pitch = (float) Math.toDegrees(Math.asin(-baseDirection.y));
+            yaw = (float) Math.toDegrees(Math.atan2(-baseDirection.x, baseDirection.z));
         }
 
         for (int i = 0; i < projectilesAmount; i++) {
@@ -117,22 +120,11 @@ public class ProjectileCastHelper {
             }
 
             AbstractArrow en = (AbstractArrow) projectile.create(world);
-            float projectilePitch = pitch + randomPitchOffset;
-            float projectileYaw = yaw + addYaw + randomYawOffset;
-
-            Vector3f finalVel;
-            if (target == null) {
-                finalVel = calculateVelocity(pitch, yaw, randomPitchOffset, addYaw, randomYawOffset);
-            } else {
-                finalVel = calculateVelocityWithBase(baseDirection, randomPitchOffset, addYaw, randomYawOffset);
-                projectilePitch = (float) Math.asin(-baseDirection.y) * Mth.RAD_TO_DEG + randomPitchOffset;
-                projectileYaw = (float) Math.atan2(-baseDirection.x, baseDirection.z) * Mth.RAD_TO_DEG + addYaw + randomYawOffset;
-            }
-
-            SpellUtils.shootProjectile(pos.add(posAdd), en, ctx.getPositionEntity(), shootSpeed, projectilePitch, projectileYaw);
+            SpellUtils.setUpProjectilePosition(pos.add(posAdd), en, ctx.getPositionEntity());
             SpellUtils.initSpellEntity(en, caster, data, holder);
 
-            en.shoot(finalVel.x, finalVel.y, finalVel.z, shootSpeed, 1);
+            Vector3f direction = calculateDirection(pitch, yaw, randomPitchOffset, addYaw, randomYawOffset);
+            en.shoot(direction.x, direction.y, direction.z, shootSpeed, 0f);
 
             if (fallDown) {
                 en.setDeltaMovement(0, -1, 0);
@@ -151,29 +143,24 @@ public class ProjectileCastHelper {
         return lifespanTicks * shootSpeed;
     }
 
-    private @NotNull Vector3f calculateVelocity(float pitch, float yaw, float randomPitchOffset, float addYaw, float randomYawOffset) {
-        Vector3f finalVel;
-        // Use original caster direction
-        float totalPitch = pitch + randomPitchOffset;
-        float totalYaw = yaw + addYaw + randomYawOffset;
+    private @NotNull Vector3f calculateDirection(float pitch, float yaw, float randomPitchOffset, float addYaw, float randomYawOffset) {
+        // Calculate direction vectors from pitch and yaw
+        float pitchRad = Math.toRadians(pitch);
+        float yawRad = Math.toRadians(yaw);
 
-        float pitchRad = Math.toRadians(totalPitch);
-        float yawRad = Math.toRadians(totalYaw);
+        float cosPitch = Mth.cos(pitchRad);
+        float sinPitch = Mth.sin(pitchRad);
+        float cosYaw = Mth.cos(yawRad);
+        float sinYaw = Mth.sin(yawRad);
 
-        // Calculate direction vector from pitch and yaw
-        float x = -Mth.sin(yawRad) * Mth.cos(pitchRad);
-        float y = -Mth.sin(pitchRad);
-        float z = Mth.cos(yawRad) * Mth.cos(pitchRad);
+        Vector3f forward = new Vector3f(-sinYaw * cosPitch, -sinPitch, cosYaw * cosPitch);
+        Vector3f right = new Vector3f(cosYaw, 0f, sinYaw);
+        Vector3f up = new Vector3f(-sinYaw * sinPitch, cosPitch, cosYaw * sinPitch);
 
-        finalVel = new Vector3f(x, y, z);
-        return finalVel;
-    }
+        float pitchOffset = Math.toRadians(randomPitchOffset);
+        float yawOffset = Math.toRadians(addYaw + randomYawOffset);
 
-    private @NotNull Vector3f calculateVelocityWithBase(Vec3 baseDirection, float randomPitchOffset, float addYaw, float randomYawOffset) {
-        // Calculate target-based direction with spread
-        float targetYaw = (float) Math.atan2(-baseDirection.x, baseDirection.z) * Mth.RAD_TO_DEG;
-        float targetPitch = (float) Math.asin(-baseDirection.y) * Mth.RAD_TO_DEG;
-        return calculateVelocity(targetPitch, targetYaw, randomPitchOffset, addYaw, randomYawOffset);
+        return forward.rotateAxis(pitchOffset, right.x, right.y, right.z).rotateAxis(-yawOffset, up.x, up.y, up.z);
     }
 
     public static Vec3 positionToVelocity(MyPosition current, MyPosition destination) {

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/ProjectileCastHelper.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/ProjectileCastHelper.java
@@ -48,6 +48,10 @@ public class ProjectileCastHelper {
     public float yaw;
     public float yawOffset;
 
+    public double offsetX;
+    public double offsetY;
+    public double offsetZ;
+
     public boolean fallDown = false;
     public boolean targetEnemy = false;
 
@@ -110,7 +114,7 @@ public class ProjectileCastHelper {
                     multiProjYawOffset = offset * apart / projectilesAmount;
                 } else if (this.castType == CastType.SPREAD_OUT_HORIZONTAL) {
                     // 1m between each projectile
-                    posAdd = getSideVelocity(caster).multiply(offset, offset, offset);
+                    posAdd = getSideVelocity(caster).scale(offset);
                 }
             }
 
@@ -121,6 +125,11 @@ public class ProjectileCastHelper {
                 randomYawOffset = (float) ((Math.random() * 2 - 1) * randomSpreadDegrees);
                 randomPitchOffset = (float) ((Math.random() * 2 - 1) * randomSpreadDegrees);
             }
+
+            // Apply offset from spell
+            posAdd = posAdd.add(getSideVelocity(caster).scale(offsetX));
+            posAdd = posAdd.add(caster.getUpVector(1f).scale(offsetY));
+            posAdd = posAdd.add(caster.getViewVector(1f).scale(offsetZ));
 
             AbstractArrow en = (AbstractArrow) projectile.create(world);
             SpellUtils.setUpProjectilePosition(pos.add(posAdd), en, ctx.getPositionEntity());

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/ProjectileCastHelper.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/ProjectileCastHelper.java
@@ -3,6 +3,7 @@ package com.robertx22.mine_and_slash.database.data.spells.components;
 import com.robertx22.library_of_exile.utils.geometry.MyPosition;
 import com.robertx22.mine_and_slash.database.data.spells.components.selectors.AoeSelector;
 import com.robertx22.mine_and_slash.database.data.spells.entities.CalculatedSpellData;
+import com.robertx22.mine_and_slash.database.data.spells.entities.IDatapackProjectileEntity;
 import com.robertx22.mine_and_slash.database.data.spells.spell_classes.SpellCtx;
 import com.robertx22.mine_and_slash.database.data.spells.spell_classes.SpellUtils;
 import com.robertx22.mine_and_slash.uncommon.effectdatas.rework.EventData;
@@ -42,8 +43,10 @@ public class ProjectileCastHelper {
     }
 
     public float pitch;
+    public float pitchOffset;
 
     public float yaw;
+    public float yawOffset;
 
     public boolean fallDown = false;
     public boolean targetEnemy = false;
@@ -91,12 +94,12 @@ public class ProjectileCastHelper {
 
             baseDirection = positionToVelocity(new MyPosition(pos), new MyPosition(target.getEyePosition()));
 
-            pitch = (float) Math.toDegrees(Math.asin(-baseDirection.y));
-            yaw = (float) Math.toDegrees(Math.atan2(-baseDirection.x, baseDirection.z));
+            pitch = (float) Math.asin(-baseDirection.y) * Mth.RAD_TO_DEG;
+            yaw = (float) Math.atan2(-baseDirection.x, baseDirection.z) * Mth.RAD_TO_DEG;
         }
 
         for (int i = 0; i < projectilesAmount; i++) {
-            float addYaw = 0;
+            float multiProjYawOffset = 0f;
             Vec3 posAdd = new Vec3(0, 0, 0);
 
             if (projectilesAmount > 1) {
@@ -104,7 +107,7 @@ public class ProjectileCastHelper {
 
                 if (this.castType == CastType.SPREAD_OUT_IN_RADIUS) {
                     // total cone is apart * (projectilesAmount - 1) / projectilesAmount
-                    addYaw = offset * apart / projectilesAmount;
+                    multiProjYawOffset = offset * apart / projectilesAmount;
                 } else if (this.castType == CastType.SPREAD_OUT_HORIZONTAL) {
                     // 1m between each projectile
                     posAdd = getSideVelocity(caster).multiply(offset, offset, offset);
@@ -123,7 +126,13 @@ public class ProjectileCastHelper {
             SpellUtils.setUpProjectilePosition(pos.add(posAdd), en, ctx.getPositionEntity());
             SpellUtils.initSpellEntity(en, caster, data, holder);
 
-            Vector3f direction = calculateDirection(pitch, yaw, randomPitchOffset, addYaw, randomYawOffset);
+            float totalPitchOffset = pitchOffset + randomPitchOffset;
+            float totalYawOffset = yawOffset + multiProjYawOffset + randomYawOffset;
+            Vector3f upVector = new Vector3f();
+            Vector3f direction = calculateDirection(pitch, yaw, totalPitchOffset, totalYawOffset, upVector);
+
+            ((IDatapackProjectileEntity) en).setVectors(direction, upVector);
+
             en.shoot(direction.x, direction.y, direction.z, shootSpeed, 0f);
 
             if (fallDown) {
@@ -143,10 +152,11 @@ public class ProjectileCastHelper {
         return lifespanTicks * shootSpeed;
     }
 
-    private @NotNull Vector3f calculateDirection(float pitch, float yaw, float randomPitchOffset, float addYaw, float randomYawOffset) {
+    private @NotNull Vector3f calculateDirection(float pitch, float yaw, float pitchOffset, float yawOffset, Vector3f outUpVector) {
         // Calculate direction vectors from pitch and yaw
-        float pitchRad = Math.toRadians(pitch);
-        float yawRad = Math.toRadians(yaw);
+        float pitchRad = (pitch + pitchOffset) * Mth.DEG_TO_RAD;
+        float yawRad = yaw * Mth.DEG_TO_RAD;
+        float yawOffsetRad = yawOffset * Mth.DEG_TO_RAD;
 
         float cosPitch = Mth.cos(pitchRad);
         float sinPitch = Mth.sin(pitchRad);
@@ -154,13 +164,9 @@ public class ProjectileCastHelper {
         float sinYaw = Mth.sin(yawRad);
 
         Vector3f forward = new Vector3f(-sinYaw * cosPitch, -sinPitch, cosYaw * cosPitch);
-        Vector3f right = new Vector3f(cosYaw, 0f, sinYaw);
-        Vector3f up = new Vector3f(-sinYaw * sinPitch, cosPitch, cosYaw * sinPitch);
+        outUpVector.set(-sinYaw * sinPitch, cosPitch, cosYaw * sinPitch);
 
-        float pitchOffset = Math.toRadians(randomPitchOffset);
-        float yawOffset = Math.toRadians(addYaw + randomYawOffset);
-
-        return forward.rotateAxis(pitchOffset, right.x, right.y, right.z).rotateAxis(-yawOffset, up.x, up.y, up.z);
+        return forward.rotateAxis(-yawOffsetRad, outUpVector.x, outUpVector.y, outUpVector.z);
     }
 
     public static Vec3 positionToVelocity(MyPosition current, MyPosition destination) {

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/ModifyProjectileAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/ModifyProjectileAction.java
@@ -1,0 +1,54 @@
+package com.robertx22.mine_and_slash.database.data.spells.components.actions;
+
+import com.robertx22.mine_and_slash.database.data.spells.components.MapHolder;
+import com.robertx22.mine_and_slash.database.data.spells.entities.IDatapackProjectileEntity;
+import com.robertx22.mine_and_slash.database.data.spells.map_fields.MapField;
+import com.robertx22.mine_and_slash.database.data.spells.spell_classes.SpellCtx;
+import net.minecraft.world.entity.LivingEntity;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+
+public class ModifyProjectileAction extends SpellAction {
+
+    public ModifyProjectileAction() {
+        super(Arrays.asList());
+    }
+
+    @Override
+    public void tryActivate(Collection<LivingEntity> targets, SpellCtx ctx, MapHolder data) {
+        ((IDatapackProjectileEntity) ctx.sourceEntity).handleModifyProjectileAction(data);
+    }
+
+    public MapHolder create(Optional<Double> projSpeed, Optional<Double> projAccel, Optional<Double> pitchOffset,
+                            Optional<Double> yawOffset, Optional<Double> yawVelocity, Optional<Double> yawAccel) {
+        MapHolder c = new MapHolder();
+        c.type = GUID();
+        if (projSpeed.isPresent()) {
+            c.put(MapField.PROJECTILE_SPEED, projSpeed.get());
+        }
+        if (projAccel.isPresent()) {
+            c.put(MapField.PROJECTILE_ACCELERATION, projAccel.get());
+        }
+        if (pitchOffset.isPresent()) {
+            c.put(MapField.PITCH_OFFSET, pitchOffset.get());
+        }
+        if (yawOffset.isPresent()) {
+            c.put(MapField.YAW_OFFSET, yawOffset.get());
+        }
+        if (yawVelocity.isPresent()) {
+            c.put(MapField.YAW_VELOCITY, yawVelocity.get());
+        }
+        if (yawAccel.isPresent()) {
+            c.put(MapField.YAW_ACCELERATION, yawAccel.get());
+        }
+        return c;
+    }
+
+    @Override
+    public String GUID() {
+        return "modify_proj";
+    }
+
+}

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/ModifyProjectileAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/ModifyProjectileAction.java
@@ -21,7 +21,7 @@ public class ModifyProjectileAction extends SpellAction {
         ((IDatapackProjectileEntity) ctx.sourceEntity).handleModifyProjectileAction(data);
     }
 
-    public MapHolder create(Optional<Double> projSpeed, Optional<Double> projAccel, Optional<Double> pitchOffset,
+    public MapHolder create(Optional<Double> projSpeed, Optional<Double> projAccel, Optional<Double> pitch, Optional<Double> pitchOffset,
                             Optional<Double> yawOffset, Optional<Double> yawVelocity, Optional<Double> yawAccel) {
         MapHolder c = new MapHolder();
         c.type = GUID();
@@ -30,6 +30,9 @@ public class ModifyProjectileAction extends SpellAction {
         }
         if (projAccel.isPresent()) {
             c.put(MapField.PROJECTILE_ACCELERATION, projAccel.get());
+        }
+        if (pitch.isPresent()) {
+            c.put(MapField.PITCH, pitch.get());
         }
         if (pitchOffset.isPresent()) {
             c.put(MapField.PITCH_OFFSET, pitchOffset.get());

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/SpellAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/SpellAction.java
@@ -36,6 +36,7 @@ public abstract class SpellAction extends BaseFieldNeeder implements IGUID {
     public static RideAction RIDE = of(new RideAction());
     public static OpenEnderChestAction OPEN_ENDER_CHEST = of(new OpenEnderChestAction());
     public static SummonProjectileAction SUMMON_PROJECTILE = of(new SummonProjectileAction());
+    public static ModifyProjectileAction MODIFY_PROJECTILE = of(new ModifyProjectileAction());
     public static DamageAction DEAL_DAMAGE = of(new DamageAction());
     public static ParticleInRadiusAction PARTICLES_IN_RADIUS = of(new ParticleInRadiusAction());
     public static SoundAction PLAY_SOUND = of(new SoundAction());

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/SummonProjectileAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/SummonProjectileAction.java
@@ -70,9 +70,17 @@ public class SummonProjectileAction extends SpellAction {
 
         builder.randomSpreadDegrees *= ctx.calculatedSpellData.data.getNumber(EventData.PROJECTILE_SPREAD_RANDOMNESS, 1).number;
 
+        if (data.has(MapField.PITCH)) {
+            builder.pitch = data.get(MapField.PITCH).floatValue();
+        }
+
         builder.pitchOffset = data.getOrDefault(MapField.PITCH_OFFSET, 0D).floatValue();
 
         builder.yawOffset = data.getOrDefault(MapField.YAW_OFFSET, 0D).floatValue();
+
+        builder.offsetX = data.getOrDefault(MapField.X_OFFSET, 0D);
+        builder.offsetY = data.getOrDefault(MapField.Y_OFFSET, 0D);
+        builder.offsetZ = data.getOrDefault(MapField.Z_OFFSET, 0D);
 
         builder.lifespanTicks = data.get(MapField.LIFESPAN_TICKS).intValue();
 

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/SummonProjectileAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/SummonProjectileAction.java
@@ -70,6 +70,10 @@ public class SummonProjectileAction extends SpellAction {
 
         builder.randomSpreadDegrees *= ctx.calculatedSpellData.data.getNumber(EventData.PROJECTILE_SPREAD_RANDOMNESS, 1).number;
 
+        builder.pitchOffset = data.getOrDefault(MapField.PITCH_OFFSET, 0D).floatValue();
+
+        builder.yawOffset = data.getOrDefault(MapField.YAW_OFFSET, 0D).floatValue();
+
         builder.lifespanTicks = data.get(MapField.LIFESPAN_TICKS).intValue();
 
         builder.cast();

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/SummonProjectileAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/SummonProjectileAction.java
@@ -70,6 +70,12 @@ public class SummonProjectileAction extends SpellAction {
 
         builder.randomSpreadDegrees *= ctx.calculatedSpellData.data.getNumber(EventData.PROJECTILE_SPREAD_RANDOMNESS, 1).number;
 
+        if (data.has(MapField.MIN_PITCH)) {
+            builder.pitch = Math.max(builder.pitch, data.get(MapField.MIN_PITCH).floatValue());
+        }
+        if (data.has(MapField.MAX_PITCH)) {
+            builder.pitch = Math.min(builder.pitch, data.get(MapField.MAX_PITCH).floatValue());
+        }
         if (data.has(MapField.PITCH)) {
             builder.pitch = data.get(MapField.PITCH).floatValue();
         }

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/conditions/OnTickCondition.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/conditions/OnTickCondition.java
@@ -22,7 +22,16 @@ public class OnTickCondition extends EffectCondition {
         }
         int ticks = data.get(MapField.TICK_RATE)
             .intValue();
-        return ctx.sourceEntity == null ? ctx.caster.tickCount % ticks == 0 : ctx.sourceEntity.tickCount % ticks == 0;
+        int firstTick = data.getOrDefault(MapField.FIRST_TICK, 0.0)
+            .intValue();
+
+        int tickCount = ctx.sourceEntity == null ? ctx.caster.tickCount : ctx.sourceEntity.tickCount;
+
+        if (ticks > 0) {
+            return tickCount >= firstTick && tickCount % ticks == firstTick % ticks;
+        } else {
+            return tickCount == firstTick;
+        }
     }
 
     public MapHolder create(Double ticks) {

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/IDatapackProjectileEntity.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/IDatapackProjectileEntity.java
@@ -2,8 +2,11 @@ package com.robertx22.mine_and_slash.database.data.spells.entities;
 
 import org.joml.Vector3f;
 
+import com.robertx22.mine_and_slash.database.data.spells.components.MapHolder;
+
 public interface IDatapackProjectileEntity {
 
     public void setVectors(Vector3f forward, Vector3f up);
+    public void handleModifyProjectileAction(MapHolder data);
 
 }

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/IDatapackProjectileEntity.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/IDatapackProjectileEntity.java
@@ -1,0 +1,9 @@
+package com.robertx22.mine_and_slash.database.data.spells.entities;
+
+import org.joml.Vector3f;
+
+public interface IDatapackProjectileEntity {
+
+    public void setVectors(Vector3f forward, Vector3f up);
+
+}

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/IDatapackProjectileEntity.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/IDatapackProjectileEntity.java
@@ -4,7 +4,7 @@ import org.joml.Vector3f;
 
 import com.robertx22.mine_and_slash.database.data.spells.components.MapHolder;
 
-public interface IDatapackProjectileEntity {
+public interface IDatapackProjectileEntity extends IDatapackSpellEntity {
 
     public void setVectors(Vector3f forward, Vector3f up);
     public void handleModifyProjectileAction(MapHolder data);

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
@@ -49,7 +49,7 @@ import java.util.UUID;
 
 import org.joml.Vector3f;
 
-public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAsItem, IDatapackSpellEntity, IDatapackProjectileEntity {
+public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAsItem, IDatapackProjectileEntity {
 
     CalculatedSpellData spellData;
 

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
@@ -15,7 +15,6 @@ import com.robertx22.mine_and_slash.uncommon.datasaving.Load;
 import com.robertx22.mine_and_slash.uncommon.effectdatas.rework.EventData;
 import com.robertx22.mine_and_slash.uncommon.utilityclasses.AllyOrEnemy;
 import com.robertx22.mine_and_slash.uncommon.utilityclasses.EntityFinder;
-import com.robertx22.mine_and_slash.uncommon.utilityclasses.PlayerUtils;
 import com.robertx22.mine_and_slash.uncommon.utilityclasses.Utilities;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.Packet;
@@ -25,7 +24,7 @@ import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
@@ -286,6 +285,26 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
 
     }
 
+    private void syncMotion() {
+        if (level() instanceof ServerLevel level) {
+            level.getChunkSource().broadcast(this, new ClientboundSetEntityMotionPacket(this));
+        }
+    }
+
+    private void setSpeed(double newSpeed) {
+        Vec3 velocity = getDeltaMovement();
+        double speed = velocity.length();
+
+        if (speed >= 1e-4) {
+            double factor = newSpeed / speed;
+            setDeltaMovement(velocity.scale(factor));
+        } else if (newSpeed != 0.0) {
+            // handle accelerating from an initial speed of 0
+            Vector3f forward = entityData.get(FORWARD_VECTOR);
+            setDeltaMovement(new Vec3(forward.mul((float) newSpeed)));
+        }
+    }
+
     private void applyAcceleration() {
         float acceleration = entityData.get(ACCELERATION);
 
@@ -295,15 +314,21 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
 
         Vec3 velocity = getDeltaMovement();
         double speed = velocity.length();
+        setSpeed(Math.max(speed + acceleration, 0.0));
+    }
 
-        if (speed >= 1e-4) {
-            double factor = Math.max(speed + acceleration, 0.0) / speed;
-            setDeltaMovement(velocity.scale(factor));
-        } else if (acceleration > 0f) {
-            // handle accelerating from an initial speed of 0
-            Vector3f forward = entityData.get(FORWARD_VECTOR);
-            setDeltaMovement(new Vec3(forward.mul(acceleration)));
-        }
+    private void adjustPitch(float angle) {
+        Vector3f velocity = getDeltaMovement().toVector3f();
+        Vector3f axis = velocity.cross(new Vector3f(0f, 1f, 0f)).normalize();
+        velocity.rotateAxis(angle * Mth.DEG_TO_RAD, axis.x, axis.y, axis.z);
+        setDeltaMovement(velocity.x, velocity.y, velocity.z);
+    }
+
+    private void adjustYaw(float angle) {
+        Vector3f velocity = getDeltaMovement().toVector3f();
+        Vector3f axis = entityData.get(UP_VECTOR);
+        velocity.rotateAxis(-angle * Mth.DEG_TO_RAD, axis.x, axis.y, axis.z);
+        setDeltaMovement(velocity.x, velocity.y, velocity.z);
     }
 
     private void applyYawVelocity() {
@@ -317,12 +342,7 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
         yawVelocity += yawAcceleration;
         entityData.set(YAW_VELOCITY, yawVelocity);
 
-        Vector3f axis = entityData.get(UP_VECTOR);
-        float angle = -yawVelocity * Mth.DEG_TO_RAD;
-
-        Vector3f velocity = getDeltaMovement().toVector3f();
-        velocity.rotateAxis(angle, axis.x, axis.y, axis.z);
-        setDeltaMovement(velocity.x, velocity.y, velocity.z);
+        adjustYaw(yawVelocity);
     }
 
     Entity target = null;
@@ -347,12 +367,7 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
                 var speed = getDeltaMovement().length();
                 var direction = ProjectileCastHelper.positionToVelocity(new MyPosition(position()), new MyPosition(target.getEyePosition()));
                 setDeltaMovement(direction.scale(speed));
-
-
-                PlayerUtils.getNearbyPlayers(level(), blockPosition(), 40)
-                        .forEach(p -> {
-                            ((ServerPlayer) p).connection.send(new ClientboundSetEntityMotionPacket(this));
-                        });
+                syncMotion();
             }
         }
     }
@@ -702,5 +717,36 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
     public void setVectors(Vector3f forward, Vector3f up) {
         this.entityData.set(FORWARD_VECTOR, forward);
         this.entityData.set(UP_VECTOR, up);
+    }
+
+    @Override
+    public void handleModifyProjectileAction(MapHolder data) {
+        boolean motionDirty = false;
+
+        if (data.has(MapField.PROJECTILE_SPEED)) {
+            setSpeed(data.get(MapField.PROJECTILE_SPEED));
+            motionDirty = true;
+        }
+        if (data.has(MapField.PROJECTILE_ACCELERATION)) {
+            entityData.set(ACCELERATION, data.get(MapField.PROJECTILE_ACCELERATION).floatValue());
+        }
+        if (data.has(MapField.PITCH_OFFSET)) {
+            adjustPitch(data.get(MapField.PITCH_OFFSET).floatValue());
+            motionDirty = true;
+        }
+        if (data.has(MapField.YAW_OFFSET)) {
+            adjustYaw(data.get(MapField.YAW_OFFSET).floatValue());
+            motionDirty = true;
+        }
+        if (data.has(MapField.YAW_VELOCITY)) {
+            entityData.set(YAW_VELOCITY, data.get(MapField.YAW_VELOCITY).floatValue());
+        }
+        if (data.has(MapField.YAW_ACCELERATION)) {
+            entityData.set(YAW_ACCELERATION, data.get(MapField.YAW_ACCELERATION).floatValue());
+        }
+
+        if (motionDirty) {
+            syncMotion();
+        }
     }
 }

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
@@ -295,6 +295,10 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
         }
     }
 
+    protected void setMotionDirty() {
+        motionDirty = true;
+    }
+
     private void setSpeed(double newSpeed) {
         Vec3 velocity = getDeltaMovement();
         double speed = velocity.length();
@@ -411,7 +415,7 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
                 var speed = getDeltaMovement().length();
                 var direction = ProjectileCastHelper.positionToVelocity(new MyPosition(position()), new MyPosition(target.getEyePosition()));
                 setDeltaMovement(direction.scale(speed));
-                motionDirty = true;
+                setMotionDirty();
             }
         }
     }
@@ -767,22 +771,22 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
     public void handleModifyProjectileAction(MapHolder data) {
         if (data.has(MapField.PROJECTILE_SPEED)) {
             setSpeed(data.get(MapField.PROJECTILE_SPEED));
-            motionDirty = true;
+            setMotionDirty();
         }
         if (data.has(MapField.PROJECTILE_ACCELERATION)) {
             entityData.set(ACCELERATION, data.get(MapField.PROJECTILE_ACCELERATION).floatValue());
         }
         if (data.has(MapField.PITCH)) {
             setPitch(data.get(MapField.PITCH).floatValue());
-            motionDirty = true;
+            setMotionDirty();
         }
         if (data.has(MapField.PITCH_OFFSET)) {
             adjustPitch(data.get(MapField.PITCH_OFFSET).floatValue());
-            motionDirty = true;
+            setMotionDirty();
         }
         if (data.has(MapField.YAW_OFFSET)) {
             adjustYaw(data.get(MapField.YAW_OFFSET).floatValue());
-            motionDirty = true;
+            setMotionDirty();
         }
         if (data.has(MapField.YAW_VELOCITY)) {
             entityData.set(YAW_VELOCITY, data.get(MapField.YAW_VELOCITY).floatValue());

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
@@ -63,8 +63,6 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
 
     public boolean moveTowardsEnemies = false;
 
-    public float yawVelocity;
-
     private static final EntityDataAccessor<CompoundTag> SPELL_DATA = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.COMPOUND_TAG);
     private static final EntityDataAccessor<String> ENTITY_NAME = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.STRING);
     private static final EntityDataAccessor<Boolean> EXPIRE_ON_ENTITY_HIT = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.BOOLEAN);
@@ -82,6 +80,8 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
     public Entity ignoreEntity;
 
     boolean collidedAlready = false;
+
+    private boolean motionDirty = false;
 
 
     @Override
@@ -265,6 +265,10 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
             return;
         }
 
+        if (motionDirty) {
+            syncMotion();
+        }
+
         try {
             onTick();
 
@@ -407,7 +411,7 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
                 var speed = getDeltaMovement().length();
                 var direction = ProjectileCastHelper.positionToVelocity(new MyPosition(position()), new MyPosition(target.getEyePosition()));
                 setDeltaMovement(direction.scale(speed));
-                syncMotion();
+                motionDirty = true;
             }
         }
     }
@@ -761,8 +765,6 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
 
     @Override
     public void handleModifyProjectileAction(MapHolder data) {
-        boolean motionDirty = false;
-
         if (data.has(MapField.PROJECTILE_SPEED)) {
             setSpeed(data.get(MapField.PROJECTILE_SPEED));
             motionDirty = true;
@@ -787,10 +789,6 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
         }
         if (data.has(MapField.YAW_ACCELERATION)) {
             entityData.set(YAW_ACCELERATION, data.get(MapField.YAW_ACCELERATION).floatValue());
-        }
-
-        if (motionDirty) {
-            syncMotion();
         }
     }
 }

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
@@ -317,6 +317,46 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
         setSpeed(Math.max(speed + acceleration, 0.0));
     }
 
+    private void setPitch(float pitch) {
+        float pitchRad = pitch * Mth.DEG_TO_RAD;
+        float cosPitch = Mth.cos(pitchRad);
+        float sinPitch = Mth.sin(pitchRad);
+
+        Vector3f velocity = getDeltaMovement().toVector3f();
+        float speed = velocity.length();
+
+        // try to determine yaw from velocity
+        float speedXY = (float) Math.sqrt(Math.fma(velocity.x, velocity.x, velocity.z * velocity.z));
+
+        if (speedXY < 1e-4f) {
+            // try to determine yaw from forward vector
+            velocity = entityData.get(FORWARD_VECTOR);
+            speedXY = (float) Math.sqrt(Math.fma(velocity.x, velocity.x, velocity.z * velocity.z));
+            if (speedXY < 1e-4f) {
+                // determine yaw from up vector
+                if (velocity.y > 0f) {
+                    // head tilted back, invert
+                    velocity = entityData.get(UP_VECTOR);
+                    velocity.x *= -1f;
+                    velocity.z *= -1f;
+                } else {
+                    velocity = entityData.get(UP_VECTOR);
+                }
+                speedXY = (float) Math.sqrt(Math.fma(velocity.x, velocity.x, velocity.z * velocity.z));
+            }
+        }
+
+        float scale = cosPitch / speedXY;
+        velocity.x *= scale;
+        velocity.z *= scale;
+
+        velocity.y = -sinPitch;
+
+        velocity.mul(speed);
+
+        setDeltaMovement(velocity.x, velocity.y, velocity.z);
+    }
+
     private void adjustPitch(float angle) {
         Vector3f velocity = getDeltaMovement().toVector3f();
         Vector3f axis = velocity.cross(new Vector3f(0f, 1f, 0f)).normalize();
@@ -729,6 +769,10 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
         }
         if (data.has(MapField.PROJECTILE_ACCELERATION)) {
             entityData.set(ACCELERATION, data.get(MapField.PROJECTILE_ACCELERATION).floatValue());
+        }
+        if (data.has(MapField.PITCH)) {
+            setPitch(data.get(MapField.PITCH).floatValue());
+            motionDirty = true;
         }
         if (data.has(MapField.PITCH_OFFSET)) {
             adjustPitch(data.get(MapField.PITCH_OFFSET).floatValue());

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
@@ -27,6 +27,7 @@ import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -47,7 +48,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAsItem, IDatapackSpellEntity {
+import org.joml.Vector3f;
+
+public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAsItem, IDatapackSpellEntity, IDatapackProjectileEntity {
 
     CalculatedSpellData spellData;
 
@@ -61,6 +64,8 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
 
     public boolean moveTowardsEnemies = false;
 
+    public float yawVelocity;
+
     private static final EntityDataAccessor<CompoundTag> SPELL_DATA = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.COMPOUND_TAG);
     private static final EntityDataAccessor<String> ENTITY_NAME = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.STRING);
     private static final EntityDataAccessor<Boolean> EXPIRE_ON_ENTITY_HIT = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.BOOLEAN);
@@ -69,6 +74,11 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
     private static final EntityDataAccessor<Integer> DEATH_TIME = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.INT);
     private static final EntityDataAccessor<Integer> CHAINS = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.INT);
     private static final EntityDataAccessor<Boolean> EXPIRE_ON_BLOCK_HIT = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.BOOLEAN);
+    private static final EntityDataAccessor<Float> ACCELERATION = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.FLOAT);
+    private static final EntityDataAccessor<Float> YAW_VELOCITY = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.FLOAT);
+    private static final EntityDataAccessor<Float> YAW_ACCELERATION = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.FLOAT);
+    private static final EntityDataAccessor<Vector3f> FORWARD_VECTOR = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.VECTOR3);
+    private static final EntityDataAccessor<Vector3f> UP_VECTOR = SynchedEntityData.defineId(SimpleProjectileEntity.class, EntityDataSerializers.VECTOR3);
 
     public Entity ignoreEntity;
 
@@ -189,6 +199,9 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
 
     public void onTick() {
 
+        applyAcceleration();
+        applyYawVelocity();
+
         if (getCaster() != null) {
 
             tryMoveTowardsTargets();
@@ -273,6 +286,45 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
 
     }
 
+    private void applyAcceleration() {
+        float acceleration = entityData.get(ACCELERATION);
+
+        if (acceleration == 0f) {
+            return;
+        }
+
+        Vec3 velocity = getDeltaMovement();
+        double speed = velocity.length();
+
+        if (speed >= 1e-4) {
+            double factor = Math.max(speed + acceleration, 0.0) / speed;
+            setDeltaMovement(velocity.scale(factor));
+        } else if (acceleration > 0f) {
+            // handle accelerating from an initial speed of 0
+            Vector3f forward = entityData.get(FORWARD_VECTOR);
+            setDeltaMovement(new Vec3(forward.mul(acceleration)));
+        }
+    }
+
+    private void applyYawVelocity() {
+        float yawVelocity = entityData.get(YAW_VELOCITY);
+        float yawAcceleration = entityData.get(YAW_ACCELERATION);
+
+        if (yawVelocity == 0f && yawAcceleration == 0f) {
+            return;
+        }
+
+        yawVelocity += yawAcceleration;
+        entityData.set(YAW_VELOCITY, yawVelocity);
+
+        Vector3f axis = entityData.get(UP_VECTOR);
+        float angle = -yawVelocity * Mth.DEG_TO_RAD;
+
+        Vector3f velocity = getDeltaMovement().toVector3f();
+        velocity.rotateAxis(angle, axis.x, axis.y, axis.z);
+        setDeltaMovement(velocity.x, velocity.y, velocity.z);
+    }
+
     Entity target = null;
 
     public void tryMoveTowardsTargets() {
@@ -292,9 +344,9 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
             }
 
             if (target != null) {
-                var vel = ProjectileCastHelper.positionToVelocity(new MyPosition(position()), new MyPosition(target.getEyePosition()));
-                vel = vel.normalize().multiply(speed, speed, speed); // todo this doesnt fix the speed problem
-                setDeltaMovement(vel);
+                var speed = getDeltaMovement().length();
+                var direction = ProjectileCastHelper.positionToVelocity(new MyPosition(position()), new MyPosition(target.getEyePosition()));
+                setDeltaMovement(direction.scale(speed));
 
 
                 PlayerUtils.getNearbyPlayers(level(), blockPosition(), 40)
@@ -541,6 +593,11 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
         this.entityData.define(PIERCE, false);
         this.entityData.define(DEATH_TIME, 100);
         this.entityData.define(CHAINS, 0);
+        this.entityData.define(ACCELERATION, 0f);
+        this.entityData.define(YAW_VELOCITY, 0f);
+        this.entityData.define(YAW_ACCELERATION, 0f);
+        this.entityData.define(FORWARD_VECTOR, new Vector3f());
+        this.entityData.define(UP_VECTOR, new Vector3f());
         super.defineSynchedData();
     }
 
@@ -625,6 +682,11 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
         this.moveTowardsEnemies = holder.getOrDefault(MapField.TRACKS_ENEMIES, false);
         this.speed = holder.getOrDefault(MapField.PROJECTILE_SPEED, 1D).floatValue();
 
+        this.entityData.set(ACCELERATION, holder.getOrDefault(MapField.PROJECTILE_ACCELERATION, 0D).floatValue());
+
+        this.entityData.set(YAW_VELOCITY, holder.getOrDefault(MapField.YAW_VELOCITY, 0D).floatValue());
+        this.entityData.set(YAW_ACCELERATION, holder.getOrDefault(MapField.YAW_ACCELERATION, 0D).floatValue());
+
         data.data.setString(EventData.ITEM_ID, holder.get(MapField.ITEM));
         CompoundTag nbt = new CompoundTag();
         nbt.putString("spell", GSON.toJson(spellData));
@@ -634,5 +696,11 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
         String name = holder.get(MapField.ENTITY_NAME);
         entityData.set(ENTITY_NAME, name);
 
+    }
+
+    @Override
+    public void setVectors(Vector3f forward, Vector3f up) {
+        this.entityData.set(FORWARD_VECTOR, forward);
+        this.entityData.set(UP_VECTOR, up);
     }
 }

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/map_fields/MapField.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/map_fields/MapField.java
@@ -52,6 +52,10 @@ public class MapField<T> implements IGUID {
     public static MapField<Double> RANDOM_X_OFFSET = make("random_x_offset");
     public static MapField<Double> RANDOM_Z_OFFSET = make("random_z_offset");
 
+    public static MapField<Double> X_OFFSET = make("x_offset");
+    public static MapField<Double> Y_OFFSET = make("y_offset");
+    public static MapField<Double> Z_OFFSET = make("z_offset");
+
     public static MapField<Double> PITCH_OFFSET = make("pitch_offset");
     public static MapField<Double> YAW_OFFSET = make("yaw_offset");
     public static MapField<Double> YAW_VELOCITY = make("yaw_velocity");

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/map_fields/MapField.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/map_fields/MapField.java
@@ -45,6 +45,8 @@ public class MapField<T> implements IGUID {
 
     public static MapField<Double> VOLUME = make("volume");
     public static MapField<Double> PITCH = make("pitch");
+    public static MapField<Double> MIN_PITCH = make("min_pitch");
+    public static MapField<Double> MAX_PITCH = make("max_pitch");
     public static MapField<Double> SECONDS = make("seconds");
     public static MapField<Double> MOTION_MULTI = make("motion_multiplier");
 

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/map_fields/MapField.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/map_fields/MapField.java
@@ -27,6 +27,7 @@ public class MapField<T> implements IGUID {
     public static MapField<Double> WIDTH = make("width");
     public static MapField<Double> CHANCE = make("chance");
     public static MapField<Double> PROJECTILE_SPEED = make("proj_speed");
+    public static MapField<Double> PROJECTILE_ACCELERATION = make("proj_accel");
     public static MapField<Double> PROJECTILES_APART = make("proj_apart");
     public static MapField<Double> SELECTION_CHANCE = make("selection_chance");
     public static MapField<Double> PUSH_STRENGTH = make("push_str");
@@ -49,7 +50,12 @@ public class MapField<T> implements IGUID {
     public static MapField<Double> RANDOM_Y_OFFSET = make("random_y_offset");
     public static MapField<Double> RANDOM_X_OFFSET = make("random_x_offset");
     public static MapField<Double> RANDOM_Z_OFFSET = make("random_z_offset");
-  
+
+    public static MapField<Double> PITCH_OFFSET = make("pitch_offset");
+    public static MapField<Double> YAW_OFFSET = make("yaw_offset");
+    public static MapField<Double> YAW_VELOCITY = make("yaw_velocity");
+    public static MapField<Double> YAW_ACCELERATION = make("yaw_acceleration");
+
     // string
     public static MapField<String> PROJECTILE_ENTITY = make("proj_en");
     public static MapField<String> SUMMONED_PET_ID = make("summon_id");

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/map_fields/MapField.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/map_fields/MapField.java
@@ -19,6 +19,7 @@ public class MapField<T> implements IGUID {
     //public static MapField<Double> MAX_SUMMONS = make("max_summons");
     public static MapField<Double> HEIGHT = make("height");
     public static MapField<Double> TICK_RATE = make("tick_rate");
+    public static MapField<Double> FIRST_TICK = make("first_tick");
     public static MapField<Double> PARTICLE_COUNT = make("particle_count");
     public static MapField<Double> Y_RANDOM = make("y_rand");
     public static MapField<Double> LIFESPAN_TICKS = make("life_ticks");

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/spell_classes/SpellUtils.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/spell_classes/SpellUtils.java
@@ -40,11 +40,16 @@ public class SpellUtils {
                         , new ClientboundAddEntityPacket(entityIn));
     }
 
-    public static void shootProjectile(Vec3 pos, AbstractArrow projectile, Entity caster, float speed,
-                                       float pitch, float yaw) {
+    public static void setUpProjectilePosition(Vec3 pos, AbstractArrow projectile, Entity caster) {
 
         ((Entity) projectile).setPos(pos.x, caster.getEyeY() - 0.1F, pos.z);
 
+    }
+
+    public static void shootProjectile(Vec3 pos, AbstractArrow projectile, Entity caster, float speed,
+                                       float pitch, float yaw) {
+
+        setUpProjectilePosition(pos, projectile, caster);
         projectile.shootFromRotation(caster, pitch, yaw, 0, speed, 1F);
 
     }


### PR DESCRIPTION
### Added new optional fields to `projectile`:
- `proj_accel` - Projectile speed changes by this much per tick
- `pitch_offset` - Add an offset in degrees from the caster's aim pitch
- `yaw_offset` - Rotate the trajectory left/right
- `yaw_velocity` - Projectile turns this many degrees left/right per tick
- `yaw_accel` - Yaw velocity changes by this much per tick

Also fixes the bug where spread decreases when looking up/down.

## Example:

```json
{
  "type": "projectile",
  "map": {
    "entity_name": "default_entity_name",
    "gravity": false,
    "item": "roe_weapons:hammer_0",
    "life_ticks": 70.0,
    "proj_count": 1.0,
    "proj_en": "mmorpg:spell_projectile",
    "proj_speed": 0.0,
    "proj_accel": 0.025,
    "yaw_velocity": 16.9085
  }
}
```

https://github.com/user-attachments/assets/9229412c-f426-4303-9d8a-22e05378a9d0

