### PR TITLE
show only unique summon duration pairs

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/Spell.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/Spell.java
@@ -351,12 +351,17 @@ public final class Spell implements ISkillGem, IGUID, IAutoGson<Spell>, JsonExil
                                 if (type.isPresent()) {
                                     name = type.get().getDescriptionId();
                                 }
-                                summons.add(new SummonTooltip(name, duration));
+                                String finalName = name;
+                                if (summons.stream().filter(i -> i.type().equals(finalName) && i.duration() == duration).findAny().isEmpty()) {
+                                    summons.add(new SummonTooltip(name, duration));
+                                }
                             }
                             if (a.has(MapField.make(MapField.BLOCK))) {
                                 float duration = a.get(MapField.LIFESPAN_TICKS).intValue();
                                 String name = this.loc_name;
-                                summons.add(new SummonTooltip(name, duration));
+                                if (summons.stream().filter(i -> i.type().equals(name) && i.duration() == duration).findAny().isEmpty()) {
+                                    summons.add(new SummonTooltip(name, duration));
+                                }
                             }
                         });
                     });


### PR DESCRIPTION
Fixes showing many identical summons entries. Long tooltip still can be an issue if skill has many of `summon_block` or `summon_pet` in attached spell, I will think how to deal with that
https://discord.com/channels/726729169999888495/1431154430501322772
<img width="1105" height="1246" alt="image" src="https://github.com/user-attachments/assets/f2bf2f48-ab6b-40dd-8d25-bc2be092abb6" />
