### PR TITLE
Support tag crafting materials in profession recipes

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/a_libraries/jei/CraftingExtension.java
+++ b/src/main/java/com/robertx22/mine_and_slash/a_libraries/jei/CraftingExtension.java
@@ -10,8 +10,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class CraftingExtension implements ICraftingCategoryExtension {
@@ -23,10 +21,7 @@ public class CraftingExtension implements ICraftingCategoryExtension {
 
     @Override
     public void setRecipe(IRecipeLayoutBuilder builder, ICraftingGridHelper craftingGridHelper, IFocusGroup focuses) {
-        List<List<ItemStack>> inputs = new ArrayList<>();
-        for (ItemStack m : recipe.getMaterials()) {
-            inputs.add(Arrays.asList(m));
-        }
+        List<List<ItemStack>> inputs = recipe.getMaterialsForJei();
 
         ItemStack resultItem = recipe.toResultStackForJei();
 

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/profession/ProfessionRecipe.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/profession/ProfessionRecipe.java
@@ -1,5 +1,6 @@
 package com.robertx22.mine_and_slash.database.data.profession;
 
+import com.google.common.collect.ImmutableList;
 import com.robertx22.library_of_exile.registry.ExileRegistryType;
 import com.robertx22.library_of_exile.registry.IAutoGson;
 import com.robertx22.library_of_exile.registry.JsonExileRegistry;
@@ -16,9 +17,13 @@ import com.robertx22.mine_and_slash.uncommon.localization.Words;
 import com.robertx22.mine_and_slash.uncommon.utilityclasses.TooltipUtils;
 import com.robertx22.temp.SkillItemTier;
 import net.minecraft.ChatFormatting;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -128,23 +133,40 @@ public class ProfessionRecipe implements JsonExileRegistry<ProfessionRecipe>, IA
         public Type type = Type.ITEM;
 
         public boolean matches(ItemStack stack) {
-            if (type == Type.ITEM) {
-                return VanillaUTIL.REGISTRY.items().getKey(stack.getItem()).toString().equals(id) && stack.getCount() >= num;
-            }
-            return false;
+            if (stack.getCount() < num) return false;
+            return hasAnyCount(stack);
         }
 
         public boolean hasAnyCount(ItemStack stack) {
             if (type == Type.ITEM) {
                 return VanillaUTIL.REGISTRY.items().getKey(stack.getItem()).toString().equals(id);
+            } else if (type == Type.TAG) {
+                return stack.is(TagKey.create(Registries.ITEM, new ResourceLocation(id)));
             }
             return false;
         }
 
-        public ItemStack toStackForJei() {
-            return new ItemStack(VanillaUTIL.REGISTRY.items().get(new ResourceLocation(id)), num);
+        public List<ItemStack> toStackForJei() {
+            if (type == Type.ITEM) {
+                return List.of(new ItemStack(VanillaUTIL.REGISTRY.items().get(new ResourceLocation(id)), num));
+            } else if (type == Type.TAG) {
+                ImmutableList.Builder<ItemStack> builder = ImmutableList.builder();
+                for (Holder<Item> holder : BuiltInRegistries.ITEM.getTagOrEmpty(TagKey.create(Registries.ITEM, new ResourceLocation(id)))) {
+                    builder.add(new ItemStack(holder.get(), num));
+                }
+                return builder.build();
+            }
+            return List.of();
         }
 
+        public Component getDisplayName() {
+            if (type == Type.ITEM) {
+                return new ItemStack(VanillaUTIL.REGISTRY.items().get(new ResourceLocation(id)), num).getDisplayName();
+            } else if (type == Type.TAG) {
+                return Words.ANY_IN_TAG.locName(id);
+            }
+            return Component.literal("???");
+        }
 
         public void spend(ItemStack stack) {
             stack.shrink(num);
@@ -237,7 +259,7 @@ public class ProfessionRecipe implements JsonExileRegistry<ProfessionRecipe>, IA
             }
             if (stacks.stream().noneMatch(x -> mat.matches(x))) {
                 fail = true;
-                msg.append(reason.word.locName(mat.toStackForJei().getDisplayName(), mat.num, have));
+                msg.append(reason.word.locName(mat.getDisplayName(), mat.num, have));
             }
         }
 
@@ -271,8 +293,12 @@ public class ProfessionRecipe implements JsonExileRegistry<ProfessionRecipe>, IA
     }
 
 
-    public List<ItemStack> getMaterials() {
-        return this.mats.stream().map(x -> x.toStackForJei()).collect(Collectors.toList());
+    public List<List<ItemStack>> getMaterialsForJei() {
+        return this.mats.stream().map(CraftingMaterial::toStackForJei).collect(Collectors.toList());
+    }
+
+    public List<CraftingMaterial> getMaterials() {
+        return this.mats;
     }
 
 

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/profession/screen/CraftingStationMenu.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/profession/screen/CraftingStationMenu.java
@@ -2,6 +2,7 @@ package com.robertx22.mine_and_slash.database.data.profession.screen;
 
 import com.robertx22.mine_and_slash.database.data.profession.Crafting_State;
 import com.robertx22.mine_and_slash.database.data.profession.ProfessionBlockEntity;
+import com.robertx22.mine_and_slash.database.data.profession.ProfessionRecipe;
 import com.robertx22.mine_and_slash.mmorpg.registers.common.SlashContainers;
 import com.robertx22.mine_and_slash.mmorpg.registers.common.items.SlashItems;
 import net.minecraft.world.Container;
@@ -126,8 +127,8 @@ public class CraftingStationMenu extends AbstractContainerMenu {
                 if (be.last_recipe == null)
                     return false;
 
-                for (ItemStack item : be.last_recipe.getMaterials()) {
-                    if (item.getItem() == pStack.getItem()) {
+                for (ProfessionRecipe.CraftingMaterial mat : be.last_recipe.getMaterials()) {
+                    if (mat.hasAnyCount(pStack)) {
                         if (be.craftingState == Crafting_State.IDLE)
                             be.craftingState = Crafting_State.ACTIVE;
                         return true;

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/profession/screen/CraftingStationScreen.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/profession/screen/CraftingStationScreen.java
@@ -119,8 +119,8 @@ public abstract class CraftingStationScreen extends AbstractContainerScreen<Craf
 
         int spacing = 18;
 
-        for (ItemStack stack : recipe.getMaterials()) {
-            var button = new ItemButton(stack, leftPos + 64 + xoff, topPos + 75 + yoff);
+        for (List<ItemStack> stack : recipe.getMaterialsForJei()) {
+            var button = new ItemButton(stack.isEmpty() ? ItemStack.EMPTY : stack.get(0), leftPos + 64 + xoff, topPos + 75 + yoff);
 
             List<Component> tip = new ArrayList<>();
             tip.add(Component.literal(UNICODE.CUBE + " ").append(Itemtips.RECIPE_MATERIAL.locName()).append(" " + UNICODE.CUBE).withStyle(ChatFormatting.RED, ChatFormatting.BOLD));

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/enumclasses/WeaponTypes.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/enumclasses/WeaponTypes.java
@@ -10,11 +10,9 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.world.damagesource.DamageSource;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class WeaponTypes implements JsonExileRegistry<WeaponTypes>, IAutoGson<WeaponTypes> {
@@ -109,7 +107,12 @@ public class WeaponTypes implements JsonExileRegistry<WeaponTypes>, IAutoGson<We
 
                 String id = source.getMsgId();
                 // todo this seems to need fixing but im afraid itll fuck things up now id = dmgid.getPath();
-                return data.containsInDmgIdPattern != null && data.containsInDmgIdPattern.matcher(id).find();
+                for (String name : data.contains_in_dmg_id) {
+                    if (id.contains(name)) {
+                        return true;
+                    }
+                }
+                return false;
             }
         };
 
@@ -124,23 +127,12 @@ public class WeaponTypes implements JsonExileRegistry<WeaponTypes>, IAutoGson<We
 
         private List<String> valid_proj_dmg_id = Arrays.asList("testmodid:name");
         private List<String> contains_in_dmg_id = Arrays.asList("arrow", "bolt", "ammo", "bullet", "dart", "missile");
-        private transient @Nullable Pattern containsInDmgIdPattern;
 
         public DamageValidityData(SourceCheck shortcheck, TagCheck tag_and_id_check, List<String> valid_proj_dmg_id, List<String> contains_in_dmg_id) {
             this.tag_and_id_check = tag_and_id_check;
             this.source_check = shortcheck;
             this.valid_proj_dmg_id = valid_proj_dmg_id;
             this.contains_in_dmg_id = contains_in_dmg_id;
-            this.init();
-        }
-
-        public void init() {
-            if (!this.contains_in_dmg_id.isEmpty()) {
-                this.containsInDmgIdPattern = Pattern.compile(
-                        this.contains_in_dmg_id.stream()
-                                .map(Pattern::quote)
-                                .collect(Collectors.joining("|")));
-            }
         }
 
         public static DamageValidityData projectile() {
@@ -227,10 +219,5 @@ public class WeaponTypes implements JsonExileRegistry<WeaponTypes>, IAutoGson<We
     @Override
     public String GUID() {
         return this.id;
-    }
-
-    @Override
-    public void onLoadedFromJson() {
-        this.damage_validity_check.init();
     }
 }

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/enumclasses/WeaponTypes.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/enumclasses/WeaponTypes.java
@@ -10,9 +10,11 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.world.damagesource.DamageSource;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class WeaponTypes implements JsonExileRegistry<WeaponTypes>, IAutoGson<WeaponTypes> {
@@ -107,12 +109,7 @@ public class WeaponTypes implements JsonExileRegistry<WeaponTypes>, IAutoGson<We
 
                 String id = source.getMsgId();
                 // todo this seems to need fixing but im afraid itll fuck things up now id = dmgid.getPath();
-                for (String name : data.contains_in_dmg_id) {
-                    if (id.contains(name)) {
-                        return true;
-                    }
-                }
-                return false;
+                return data.containsInDmgIdPattern != null && data.containsInDmgIdPattern.matcher(id).find();
             }
         };
 
@@ -127,12 +124,23 @@ public class WeaponTypes implements JsonExileRegistry<WeaponTypes>, IAutoGson<We
 
         private List<String> valid_proj_dmg_id = Arrays.asList("testmodid:name");
         private List<String> contains_in_dmg_id = Arrays.asList("arrow", "bolt", "ammo", "bullet", "dart", "missile");
+        private transient @Nullable Pattern containsInDmgIdPattern;
 
         public DamageValidityData(SourceCheck shortcheck, TagCheck tag_and_id_check, List<String> valid_proj_dmg_id, List<String> contains_in_dmg_id) {
             this.tag_and_id_check = tag_and_id_check;
             this.source_check = shortcheck;
             this.valid_proj_dmg_id = valid_proj_dmg_id;
             this.contains_in_dmg_id = contains_in_dmg_id;
+            this.init();
+        }
+
+        public void init() {
+            if (!this.contains_in_dmg_id.isEmpty()) {
+                this.containsInDmgIdPattern = Pattern.compile(
+                        this.contains_in_dmg_id.stream()
+                                .map(Pattern::quote)
+                                .collect(Collectors.joining("|")));
+            }
         }
 
         public static DamageValidityData projectile() {
@@ -219,5 +227,10 @@ public class WeaponTypes implements JsonExileRegistry<WeaponTypes>, IAutoGson<We
     @Override
     public String GUID() {
         return this.id;
+    }
+
+    @Override
+    public void onLoadedFromJson() {
+        this.damage_validity_check.init();
     }
 }

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/localization/Words.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/localization/Words.java
@@ -35,6 +35,7 @@ public enum Words implements IAutoLocName {
     CRAFT_FAILED("Craft Failed due to incorrect materials"),
     NO_ITEM_FOUND("\n- %1$s is missing"),
     NOT_ENOUGH_ITEM_FOUND("\n- %1$s needs %2$s items but you only inserted %3$s "),
+    ANY_IN_TAG("Any Item in Tag #%1$s"),
     OPTION_LOCKED_UNTIL_BOSS_KILLED("Option Locked Until Map Boss is Killed."),
     MAP_IS_ALREADY_MAX_RARITY("Map is already at Maximum Rarity."),
     NO_MAP_TO_UPGRADE("You don't have any map currently."),


### PR DESCRIPTION
Adds support for crafting materials with `"type": "TAG"`.

TODO:

* memoize result of `toStackForJei` for performance?
* make display of tag materials cycle in the crafting station screen
* We’re parsing into `ResourceLocation`s a lot; perhaps it might be worth installing a type adapter for them in LoE’s `IAutoGson#createGson`. This would also allow validating resource locations ahead of time and properly handling those with an implicit `minecraft` namespace.
* The `FOOD` and `MEAT` types are completely unused; maybe we should remove them