### PR TITLE
Permanent map layout

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/maps/MapItemData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/maps/MapItemData.java
@@ -3,7 +3,7 @@ package com.robertx22.mine_and_slash.maps;
 import com.google.common.collect.ImmutableMap;
 import com.robertx22.dungeon_realm.item.DungeonItemMapData;
 import com.robertx22.dungeon_realm.item.DungeonItemNbt;
-import com.robertx22.dungeon_realm.main.DungeonWords;
+import com.robertx22.dungeon_realm.tooltip.MapTooltip;
 import com.robertx22.library_of_exile.utils.ItemstackDataSaver;
 import com.robertx22.mine_and_slash.aoe_data.database.stats.OffenseStats;
 import com.robertx22.mine_and_slash.config.forge.ServerContainer;
@@ -222,9 +222,9 @@ public class MapItemData implements ICommonDataItem<GearRarity> {
                     DungeonItemMapData dungeonData = DungeonItemNbt.DUNGEON_MAP.loadFrom(stack.getStack());
 
                     if (dungeonData != null) {
-                        additional.add(DungeonWords.MAP_LAYOUT.get(dungeonData.dungeon).withStyle(ChatFormatting.GRAY, ChatFormatting.GREEN));
+                        additional.add(MapTooltip.MapLayoutName(dungeonData.dungeon));
                         if (dungeonData.uber) {
-                            additional.add(DungeonWords.MAP_HAS_UBER_ARENA.get().withStyle(ChatFormatting.RED, ChatFormatting.BOLD)); // Added Uber Map indicator
+                            additional.add(MapTooltip.MapHasUber()); // Added Uber Map indicator
                         }
                     }
 

--- a/src/main/java/com/robertx22/mine_and_slash/maps/MapItemData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/maps/MapItemData.java
@@ -1,10 +1,10 @@
 package com.robertx22.mine_and_slash.maps;
 
 import com.google.common.collect.ImmutableMap;
-import com.robertx22.library_of_exile.utils.ItemstackDataSaver;
 import com.robertx22.dungeon_realm.item.DungeonItemMapData;
 import com.robertx22.dungeon_realm.item.DungeonItemNbt;
-import com.robertx22.library_of_exile.utils.RandomUtils;
+import com.robertx22.dungeon_realm.main.DungeonWords;
+import com.robertx22.library_of_exile.utils.ItemstackDataSaver;
 import com.robertx22.mine_and_slash.aoe_data.database.stats.OffenseStats;
 import com.robertx22.mine_and_slash.config.forge.ServerContainer;
 import com.robertx22.mine_and_slash.database.data.game_balance_config.GameBalanceConfig;
@@ -221,8 +221,11 @@ public class MapItemData implements ICommonDataItem<GearRarity> {
                     // Load DungeonItemMapData and check for uber status
                     DungeonItemMapData dungeonData = DungeonItemNbt.DUNGEON_MAP.loadFrom(stack.getStack());
 
-                    if (dungeonData != null && dungeonData.uber) {
-                        additional.add(Component.literal("Uber Map").withStyle(ChatFormatting.RED)); // Added Uber Map indicator
+                    if (dungeonData != null) {
+                        additional.add(DungeonWords.MAP_LAYOUT.get(dungeonData.dungeon).withStyle(ChatFormatting.GRAY, ChatFormatting.GREEN));
+                        if (dungeonData.uber) {
+                            additional.add(DungeonWords.MAP_HAS_UBER_ARENA.get().withStyle(ChatFormatting.RED, ChatFormatting.BOLD)); // Added Uber Map indicator
+                        }
                     }
 
                     if (!tooltipInfo.shouldShowDescriptions()) {

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/testing/CommandTests.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/testing/CommandTests.java
@@ -34,7 +34,7 @@ public class CommandTests {
         reg(new GivePlayerCapNbt());
         reg(new CheckRunewordConflictTest());
         reg(new GenerateGearTest());
-
+        reg(new DungeonNamesTest());
 
     }
 

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/testing/tests/DungeonNamesTest.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/testing/tests/DungeonNamesTest.java
@@ -1,0 +1,30 @@
+package com.robertx22.mine_and_slash.uncommon.testing.tests;
+
+import com.robertx22.dungeon_realm.database.DungeonDatabase;
+import com.robertx22.dungeon_realm.main.DungeonWords;
+import com.robertx22.mine_and_slash.uncommon.testing.CommandTest;
+import com.robertx22.mine_and_slash.uncommon.testing.TestResult;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+public class DungeonNamesTest extends CommandTest {
+    @Override
+    public TestResult runINTERNAL(ServerPlayer player) {
+        player.sendSystemMessage(Component.literal("Map translation key - Value"));
+        DungeonDatabase.Dungeons().getAll().forEach((id, dungeon) -> {
+            String translationKey = DungeonWords.MapGUID(dungeon.id);
+            player.sendSystemMessage(Component.literal(translationKey).append(Component.literal(" - ")).append(Component.translatable(translationKey)));
+        });
+        return TestResult.SUCCESS;
+    }
+
+    @Override
+    public boolean shouldRunEveryLogin() {
+        return true;
+    }
+
+    @Override
+    public String GUID() {
+        return "dungeon_names";
+    }
+}

--- a/src/main/java/com/robertx22/mine_and_slash/vanilla_mc/commands/report/ReportMapIssue.java
+++ b/src/main/java/com/robertx22/mine_and_slash/vanilla_mc/commands/report/ReportMapIssue.java
@@ -2,6 +2,7 @@ package com.robertx22.mine_and_slash.vanilla_mc.commands.report;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.robertx22.dungeon_realm.main.DungeonMain;
+import com.robertx22.dungeon_realm.structure.DungeonMapData;
 import com.robertx22.dungeon_realm.structure.DungeonMapStructure;
 import com.robertx22.library_of_exile.dimension.structure.dungeon.BuiltRoom;
 import com.robertx22.library_of_exile.dimension.structure.dungeon.DungeonBuilder;
@@ -12,6 +13,8 @@ import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Optional;
 
 import static net.minecraft.commands.Commands.literal;
 
@@ -35,7 +38,13 @@ public class ReportMapIssue {
 
                 String text = "Map Bug Report, Problem Room: ";
 
-                DungeonBuilder builder = new DungeonBuilder(DungeonMapStructure.dungeonSettings(p.chunkPosition()));
+                Optional<DungeonMapData> dungeonMapData = DungeonMain.ifMapData(p.level(), p.getOnPos());
+                if (dungeonMapData.isEmpty()) {
+                    p.sendSystemMessage(Component.literal(ChatFormatting.RED + "You must be standing in a dungeon to use this command."));
+                    return 1;
+                }
+
+                DungeonBuilder builder = new DungeonBuilder(DungeonMapStructure.dungeonSettings(p.chunkPosition(), dungeonMapData.get().dungeon));
                 builder.build();
                 BuiltRoom room = builder.builtDungeon.getRoomForChunk(DungeonMain.MAIN_DUNGEON_STRUCTURE, p.chunkPosition());
 


### PR DESCRIPTION
Must be applied concurrently with: https://github.com/mahjerion/dungeon_realm/pull/5 https://github.com/mahjerion/Library-of-Exile-Rework/pull/6

I added a new test `/mine_and_slash runtest dungeon_names` that shows what layout has what name. Name is just a regular translation key and dungeon realm has some default names already https://github.com/mahjerion/dungeon_realm/pull/5

Here are missing translations from my CtE client:
```
dungeon_realm.words.map_name_template - dungeon_realm.words.map_name_template
dungeon_realm.words.map_name_watcher - dungeon_realm.words.map_name_watcher
dungeon_realm.words.map_name_moo - dungeon_realm.words.map_name_moo
dungeon_realm.words.map_name_pirate_lair - dungeon_realm.words.map_name_pirate_lair
dungeon_realm.words.map_name_garden - dungeon_realm.words.map_name_garden
```

Here are default map names from `Dungeon Realm`:
```
Map translation key - Value
dungeon_realm.words.map_name_mine - Mine
dungeon_realm.words.map_name_tent - Tent
dungeon_realm.words.map_name_nether - Nether
dungeon_realm.words.map_name_sewer2 - Sewer 2
dungeon_realm.words.map_name_steampunk - Steampunk
dungeon_realm.words.map_name_nature - Nature
dungeon_realm.words.map_name_sewers - Sewers
dungeon_realm.words.map_name_it - IT
dungeon_realm.words.map_name_sandstone - Sandstone
dungeon_realm.words.map_name_spruce_mansion - Spruce Mansion
dungeon_realm.words.map_name_night_terror - Night Terror
dungeon_realm.words.map_name_cement - Cement
dungeon_realm.words.map_name_wn - WN
dungeon_realm.words.map_name_pyramid - Pyramid
dungeon_realm.words.map_name_end - The End
dungeon_realm.words.map_name_stone_brick - Stone Brick
dungeon_realm.words.map_name_warped - Warped
dungeon_realm.words.map_name_bastion - Bastion
dungeon_realm.words.map_name_mossy_brick - Mossy Brick
```