### PR TITLE
Fix issue with keyboard autorepeat filling up spell input stack

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/event_hooks/player/OnKeyPress.java
+++ b/src/main/java/com/robertx22/mine_and_slash/event_hooks/player/OnKeyPress.java
@@ -108,7 +108,9 @@ public class OnKeyPress {
 
     private static boolean checkToAddSpellKeyPress(SpellKeybind key) {
         if (key.key.consumeClick()) {
-            spellKeysPressed.add(key);
+            if (!spellKeysPressed.contains(key)) {
+                spellKeysPressed.add(key);
+            }
             // Consume any remaining clicks
             while (key.key.consumeClick()) {
             }


### PR DESCRIPTION
This was causing issues when holding down a spell on the keyboard and then trying to override the input with a spell on a mouse button; the keyboard autorepeat would immediately override the mouse input