### PR TITLE
Make new projectile features support projectile speed stat

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/aoe_data/database/stat_effects/StatEffects.java
+++ b/src/main/java/com/robertx22/mine_and_slash/aoe_data/database/stat_effects/StatEffects.java
@@ -162,6 +162,7 @@ public class StatEffects implements ExileRegistryInit {
     public static StatEffect DECREASE_COOLDOWN_BY_X_TICKS = new AddToNumberEffect("reduce_cd_by_ticks", EventData.COOLDOWN_TICKS, NumberProvider.ofStatData());
     public static StatEffect INCREASE_MANA_COST = new IncreaseNumberByPercentEffect(EventData.MANA_COST);
     public static StatEffect INCREASE_PROJ_SPEED = new IncreaseNumberByPercentEffect(EventData.PROJECTILE_SPEED_MULTI);
+    public static StatEffect INCREASE_PROJ_YAW_SPEED = new IncreaseNumberByPercentEffect(EventData.PROJECTILE_YAW_SPEED_MULTI);
     public static StatEffect INCREASE_PROJ_SPREAD_RANDOMNESS = new IncreaseNumberByPercentEffect(EventData.PROJECTILE_SPREAD_RANDOMNESS);
     public static StatEffect PROJECTILE_COUNT = new AddToNumberEffect("proj_count", EventData.BONUS_PROJECTILES, NumberProvider.ofStatData());
     public static StatEffect BONUS_CHAINS = new AddToNumberEffect("bonus_chains", EventData.BONUS_CHAINS, NumberProvider.ofStatData());

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
@@ -83,6 +83,7 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
 
     private boolean motionDirty = false;
 
+    private Float cachedSpeedMultiplier = null;
 
     @Override
     protected ItemStack getPickupItem() {
@@ -123,6 +124,13 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
 
     public void setDeathTime(int newVal) {
         this.entityData.set(DEATH_TIME, newVal);
+    }
+
+    public float getSpeedMultiplier() {
+        if (cachedSpeedMultiplier == null) {
+            cachedSpeedMultiplier = getSpellData().data.getNumber(EventData.PROJECTILE_SPEED_MULTI, 1F).number;
+        }
+        return cachedSpeedMultiplier;
     }
 
     public SimpleProjectileEntity(EntityType<? extends Entity> type, Level worldIn) {
@@ -745,10 +753,13 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
         this.moveTowardsEnemies = holder.getOrDefault(MapField.TRACKS_ENEMIES, false);
         this.speed = holder.getOrDefault(MapField.PROJECTILE_SPEED, 1D).floatValue();
 
-        this.entityData.set(ACCELERATION, holder.getOrDefault(MapField.PROJECTILE_ACCELERATION, 0D).floatValue());
+        // scale all projectile movement (except gravity) by speed
+        float speedMultiplier = getSpeedMultiplier();
 
-        this.entityData.set(YAW_VELOCITY, holder.getOrDefault(MapField.YAW_VELOCITY, 0D).floatValue());
-        this.entityData.set(YAW_ACCELERATION, holder.getOrDefault(MapField.YAW_ACCELERATION, 0D).floatValue());
+        this.entityData.set(ACCELERATION, holder.getOrDefault(MapField.PROJECTILE_ACCELERATION, 0D).floatValue() * speedMultiplier);
+
+        this.entityData.set(YAW_VELOCITY, holder.getOrDefault(MapField.YAW_VELOCITY, 0D).floatValue() * speedMultiplier);
+        this.entityData.set(YAW_ACCELERATION, holder.getOrDefault(MapField.YAW_ACCELERATION, 0D).floatValue() * speedMultiplier);
 
         data.data.setString(EventData.ITEM_ID, holder.get(MapField.ITEM));
         CompoundTag nbt = new CompoundTag();
@@ -770,11 +781,11 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
     @Override
     public void handleModifyProjectileAction(MapHolder data) {
         if (data.has(MapField.PROJECTILE_SPEED)) {
-            setSpeed(data.get(MapField.PROJECTILE_SPEED));
+            setSpeed(data.get(MapField.PROJECTILE_SPEED) * getSpeedMultiplier());
             setMotionDirty();
         }
         if (data.has(MapField.PROJECTILE_ACCELERATION)) {
-            entityData.set(ACCELERATION, data.get(MapField.PROJECTILE_ACCELERATION).floatValue());
+            entityData.set(ACCELERATION, data.get(MapField.PROJECTILE_ACCELERATION).floatValue() * getSpeedMultiplier());
         }
         if (data.has(MapField.PITCH)) {
             setPitch(data.get(MapField.PITCH).floatValue());
@@ -789,10 +800,10 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
             setMotionDirty();
         }
         if (data.has(MapField.YAW_VELOCITY)) {
-            entityData.set(YAW_VELOCITY, data.get(MapField.YAW_VELOCITY).floatValue());
+            entityData.set(YAW_VELOCITY, data.get(MapField.YAW_VELOCITY).floatValue() * getSpeedMultiplier());
         }
         if (data.has(MapField.YAW_ACCELERATION)) {
-            entityData.set(YAW_ACCELERATION, data.get(MapField.YAW_ACCELERATION).floatValue());
+            entityData.set(YAW_ACCELERATION, data.get(MapField.YAW_ACCELERATION).floatValue() * getSpeedMultiplier());
         }
     }
 }

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/entities/SimpleProjectileEntity.java
@@ -84,6 +84,7 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
     private boolean motionDirty = false;
 
     private Float cachedSpeedMultiplier = null;
+    private Float cachedYawSpeedMultiplier = null;
 
     @Override
     protected ItemStack getPickupItem() {
@@ -131,6 +132,13 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
             cachedSpeedMultiplier = getSpellData().data.getNumber(EventData.PROJECTILE_SPEED_MULTI, 1F).number;
         }
         return cachedSpeedMultiplier;
+    }
+
+    public float getYawSpeedMultiplier() {
+        if (cachedYawSpeedMultiplier == null) {
+            cachedYawSpeedMultiplier = getSpellData().data.getNumber(EventData.PROJECTILE_YAW_SPEED_MULTI, 1F).number;
+        }
+        return cachedYawSpeedMultiplier;
     }
 
     public SimpleProjectileEntity(EntityType<? extends Entity> type, Level worldIn) {
@@ -753,13 +761,10 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
         this.moveTowardsEnemies = holder.getOrDefault(MapField.TRACKS_ENEMIES, false);
         this.speed = holder.getOrDefault(MapField.PROJECTILE_SPEED, 1D).floatValue();
 
-        // scale all projectile movement (except gravity) by speed
-        float speedMultiplier = getSpeedMultiplier();
+        this.entityData.set(ACCELERATION, holder.getOrDefault(MapField.PROJECTILE_ACCELERATION, 0D).floatValue() * getSpeedMultiplier());
 
-        this.entityData.set(ACCELERATION, holder.getOrDefault(MapField.PROJECTILE_ACCELERATION, 0D).floatValue() * speedMultiplier);
-
-        this.entityData.set(YAW_VELOCITY, holder.getOrDefault(MapField.YAW_VELOCITY, 0D).floatValue() * speedMultiplier);
-        this.entityData.set(YAW_ACCELERATION, holder.getOrDefault(MapField.YAW_ACCELERATION, 0D).floatValue() * speedMultiplier);
+        this.entityData.set(YAW_VELOCITY, holder.getOrDefault(MapField.YAW_VELOCITY, 0D).floatValue() * getYawSpeedMultiplier());
+        this.entityData.set(YAW_ACCELERATION, holder.getOrDefault(MapField.YAW_ACCELERATION, 0D).floatValue() * getYawSpeedMultiplier());
 
         data.data.setString(EventData.ITEM_ID, holder.get(MapField.ITEM));
         CompoundTag nbt = new CompoundTag();
@@ -800,10 +805,10 @@ public class SimpleProjectileEntity extends AbstractArrow implements IMyRenderAs
             setMotionDirty();
         }
         if (data.has(MapField.YAW_VELOCITY)) {
-            entityData.set(YAW_VELOCITY, data.get(MapField.YAW_VELOCITY).floatValue() * getSpeedMultiplier());
+            entityData.set(YAW_VELOCITY, data.get(MapField.YAW_VELOCITY).floatValue() * getYawSpeedMultiplier());
         }
         if (data.has(MapField.YAW_ACCELERATION)) {
-            entityData.set(YAW_ACCELERATION, data.get(MapField.YAW_ACCELERATION).floatValue() * getSpeedMultiplier());
+            entityData.set(YAW_ACCELERATION, data.get(MapField.YAW_ACCELERATION).floatValue() * getYawSpeedMultiplier());
         }
     }
 }

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/SpellStatsCalculationEvent.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/SpellStatsCalculationEvent.java
@@ -60,6 +60,7 @@ public class SpellStatsCalculationEvent extends EffectEvent {
         this.data.setupNumber(EventData.COOLDOWN_TICKS, spell.config.cooldown_ticks);
         this.data.setupNumber(EventData.CHARGE_COOLDOWN_TICKS, spell.config.charge_regen);
         this.data.setupNumber(EventData.PROJECTILE_SPEED_MULTI, 1F);
+        this.data.setupNumber(EventData.PROJECTILE_YAW_SPEED_MULTI, 1F);
         this.data.setupNumber(EventData.PROJECTILE_SPREAD_RANDOMNESS, 1F);
         this.data.setupNumber(EventData.DURATION_MULTI, 1F);
         this.data.setupNumber(EventData.AREA_MULTI, 1);

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/rework/EventData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/effectdatas/rework/EventData.java
@@ -63,6 +63,7 @@ public class EventData {
     public static String PIERCE = "pierce";
     public static String BARRAGE = "barrage";
     public static String PROJECTILE_SPEED_MULTI = "proj_speed";
+    public static String PROJECTILE_YAW_SPEED_MULTI = "proj_yaw_speed";
     public static String PROJECTILE_SPREAD_RANDOMNESS = "proj_spread_randomness";
     public static String BONUS_PROJECTILES = "bonus_proj";
     public static String BONUS_CHAINS = "bonus_chains";


### PR DESCRIPTION
Projectile speed multiplier will now scale initial acceleration and speed/acceleration from `modify_proj`, and `proj_yaw_speed` has been added as an event number for scaling yaw speed/acceleration.

Example spell+stats: [blessed_hammer.zip](https://github.com/user-attachments/files/23252341/blessed_hammer.zip)