### PR TITLE
Handle unexpected nan in entity delta movement

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/SpellMotionAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/SpellMotionAction.java
@@ -5,6 +5,7 @@ import com.robertx22.mine_and_slash.database.data.spells.components.MapHolder;
 import com.robertx22.mine_and_slash.database.data.spells.components.actions.vanity.ParticleMotion;
 import com.robertx22.mine_and_slash.database.data.spells.map_fields.MapField;
 import com.robertx22.mine_and_slash.database.data.spells.spell_classes.SpellCtx;
+import com.robertx22.mine_and_slash.uncommon.utilityclasses.ExileEffectUtils;
 import com.robertx22.mine_and_slash.uncommon.utilityclasses.PlayerUtils;
 import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket;
 import net.minecraft.server.level.ServerPlayer;
@@ -59,7 +60,7 @@ public class SpellMotionAction extends SpellAction {
                             x.setDeltaMovement(motionWithY);
                         }
                     } else {
-                        x.setDeltaMovement(x.getDeltaMovement()
+                        x.setDeltaMovement(ExileEffectUtils.EnsureNotNaN(x.getDeltaMovement())
                                 .add(motionWithY));
                     }
 

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/vanity/ParticleInRadiusAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/vanity/ParticleInRadiusAction.java
@@ -1,11 +1,12 @@
 package com.robertx22.mine_and_slash.database.data.spells.components.actions.vanity;
 
+import com.robertx22.library_of_exile.main.Packets;
 import com.robertx22.mine_and_slash.database.data.spells.components.MapHolder;
 import com.robertx22.mine_and_slash.database.data.spells.components.actions.SpellAction;
 import com.robertx22.mine_and_slash.database.data.spells.components.packets.ParticlesPacket;
 import com.robertx22.mine_and_slash.database.data.spells.spell_classes.SpellCtx;
 import com.robertx22.mine_and_slash.uncommon.effectdatas.rework.EventData;
-import com.robertx22.library_of_exile.main.Packets;
+import com.robertx22.mine_and_slash.uncommon.utilityclasses.ExileEffectUtils;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.LivingEntity;
@@ -55,7 +56,7 @@ public class ParticleInRadiusAction extends SpellAction {
             float motionMulti = data.getOrDefault(MOTION_MULTI, 1D).floatValue();
 
             Vec3 pos = ctx.getPos();
-            Vec3 vel = ctx.getPositionEntity().getDeltaMovement();
+            Vec3 vel = ExileEffectUtils.EnsureNotNaN(ctx.getPositionEntity().getDeltaMovement());
 
 
             ParticlesPacket.Data saved = new ParticlesPacket.Data();

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/utilityclasses/DashUtils.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/utilityclasses/DashUtils.java
@@ -39,7 +39,7 @@ public class DashUtils {
 
         if (f > 0.0F) {
             en.hasImpulse = true;
-            Vec3 vec3d = en.getDeltaMovement();
+            Vec3 vec3d = ExileEffectUtils.EnsureNotNaN(en.getDeltaMovement());
             Vec3 vec3d2 = (new Vec3(d, 0.0D, e)).normalize()
                     .scale((double) f);
             en.setDeltaMovement(vec3d.x / 2.0D - vec3d2.x, en.onGround() ? Math.min(0.4D, vec3d.y / 2.0D + (double) f) : vec3d.y, vec3d.z / 2.0D - vec3d2.z);

--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/utilityclasses/ExileEffectUtils.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/utilityclasses/ExileEffectUtils.java
@@ -5,6 +5,7 @@ import com.robertx22.mine_and_slash.database.registry.ExileDB;
 import com.robertx22.mine_and_slash.tags.imp.EffectTag;
 import com.robertx22.mine_and_slash.uncommon.datasaving.Load;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.phys.Vec3;
 
 public class ExileEffectUtils {
 
@@ -23,5 +24,21 @@ public class ExileEffectUtils {
 
         return amount;
 
+    }
+
+    public static Vec3 EnsureNotNaN(Vec3 v) {
+        if (Double.isNaN(v.x)) {
+            v = new Vec3(0, v.y, v.z);
+        }
+
+        if (Double.isNaN(v.y)) {
+            v = new Vec3(v.x, 0, v.z);
+        }
+
+        if (Double.isNaN(v.z)) {
+            v = new Vec3(v.x, v.y, 0);
+        }
+
+        return v;
     }
 }


### PR DESCRIPTION
Mutant Creeper produces NaN values after it hits

There is something weird about this issue - https://discord.com/channels/726729169999888495/1429577487301480548

You can reproduce it consistently when standing on top of the treasure room portal as I described here - https://github.com/Fuzss/mutantmonsters/issues/119