### PR TITLE
Fix on_entity_expire not working in effects

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/vanilla_mc/potion_effects/EntityStatusEffectsData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/vanilla_mc/potion_effects/EntityStatusEffectsData.java
@@ -44,14 +44,12 @@ public class EntityStatusEffectsData {
 
 
         // todo this is probably bit laggy per tick no?
-        List<ExileEffect> removed = new ArrayList<>();
-
         if (en.tickCount % 80 == 0) {
             // Prevent keeping e.g. auras and stances after respeccing
             // Has to string compare spell UUIDs to look up the new spell level, so it's done infrequently
             exileMap.entrySet().removeIf(x -> {
                 if (x.getValue().shouldRemove() || x.getValue().isSpellNoLongerAllocated(en)) {
-                    removed.add(ExileDB.ExileEffects().get(x.getKey()));
+                    ExileDB.ExileEffects().get(x.getKey()).onRemove(en);
                     return true;
                 }
                 return false;
@@ -59,15 +57,11 @@ public class EntityStatusEffectsData {
         } else {
             exileMap.entrySet().removeIf(x -> {
                 if (x.getValue().shouldRemove()) {
-                    removed.add(ExileDB.ExileEffects().get(x.getKey()));
+                    ExileDB.ExileEffects().get(x.getKey()).onRemove(en);
                     return true;
                 }
                 return false;
             });
-        }
-
-        for (ExileEffect eff : removed) {
-            eff.onRemove(en);
         }
 
     }


### PR DESCRIPTION
Calls `ExileEffect.onRemove` *before* removing the effect so that `onRemove` can successfully find the `ExileEffectInstanceData` on the entity