### PR TITLE
Potential fix for null ptr exception from accessing stale DROPPED StackData

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/itemstack/StackData.java
+++ b/src/main/java/com/robertx22/mine_and_slash/itemstack/StackData.java
@@ -46,6 +46,7 @@ public class StackData<T> {
 
     public void delete() {
         saver.removeFrom(stack.getStack());
+        resetGetterCache();
     }
 
     public T createDefault() {


### PR DESCRIPTION
Fix StackData getter potentially keeping deleted dropped item data cached when an item is dropped again after being picked up