### PR TITLE
Allow forceUnequipItem to handle empty spaces

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/uncommon/utilityclasses/PlayerUtils.java
+++ b/src/main/java/com/robertx22/mine_and_slash/uncommon/utilityclasses/PlayerUtils.java
@@ -40,6 +40,9 @@ public class PlayerUtils {
     }
 
     public static void forceUnequipItem(ItemStack stack, Player player) {
+        if (stack.isEmpty()) {
+            return;
+        }
         if (player.addItem(stack) == false) {
             forceDropItem(stack, player);
         }


### PR DESCRIPTION
Support gems and augments were failing to forceUnequipItem if there was emtpy space which allowed duplicated/overallocated gems/augments without them being unequipped.