### PR TITLE
New spell language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ ignore/
 remappedSrc
 remappedSrc/
 /libs
+.antlr

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java-library'
     id 'net.neoforged.moddev.legacyforge' version "2.0.107"
     id "me.modmuss50.mod-publish-plugin" version "0.8.4"
+    id 'antlr'
 }
 
 //archivesBaseName = "${mod_archive_name}-${minecraft_version}"
@@ -20,9 +21,18 @@ base {
     archivesName = "${mod_archive_name}-${minecraft_version}"
 }
 
+sourceSets.main.java {
+    srcDir 'build/generated-src/antlr'
+}
+
 sourceSets.main.resources{
     srcDir 'src/generated/resources'
     exclude '.cache/**'
+}
+
+generateGrammarSource {
+    //arguments += ["-visitor", "-package", "com.robertx22.mine_and_slash.antlr"]
+    arguments += ["-visitor", "-package", "com.robertx22.mine_and_slash.antlr"]
 }
 
 legacyForge {
@@ -159,6 +169,8 @@ dependencies {
     modImplementation("com.robertx22:the_harvest:${project.the_harvest_version}")
     modImplementation("com.robertx22:dungeon_realm:${project.dungeon_realm_version}")
     //modImplementation("maven.modrinth:library-of-exile:${project.exile_library_version}")
+
+    antlr "org.antlr:antlr4:4.5" // use ANTLR version 4
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ sourceSets.main.resources{
 }
 
 generateGrammarSource {
-    //arguments += ["-visitor", "-package", "com.robertx22.mine_and_slash.antlr"]
     arguments += ["-visitor", "-package", "com.robertx22.mine_and_slash.antlr"]
 }
 

--- a/src/main/antlr/com/robertx22/mine_and_slash/antlr/Spell.g4
+++ b/src/main/antlr/com/robertx22/mine_and_slash/antlr/Spell.g4
@@ -45,7 +45,7 @@ enPredPrefix: 'en' '.';
 condition: enPredPrefix? mapHolder; // single condition
 conditionParen: '(' conditionExpr ')' | condition;
 conditionNot: Not conditionParen | conditionParen;
-conditionAnd: conditionNot (And conditionNot)*;
+conditionAnd: conditionNot ('&&' conditionNot)*;
 conditionExpr: conditionAnd;
 
 // corresponds to MapHolder with type and map
@@ -66,7 +66,6 @@ bool: True | False;
  */
 
 Not: '!';
-And: '&&';
 
 OnCast: 'on_cast';
 OnTick: 'on_tick';

--- a/src/main/antlr/com/robertx22/mine_and_slash/antlr/Spell.g4
+++ b/src/main/antlr/com/robertx22/mine_and_slash/antlr/Spell.g4
@@ -31,18 +31,18 @@ entityName: Identifier;
 
 // spell action syntax
 scriptBlock: '{' scriptStatement* '}' | scriptStatement;
-scriptStatement: ifBlock | selectBlock | actions;
+scriptStatement: ifBlock | filterBlock | selectBlock | actions;
 ifBlock: 'if' '(' conditionExpr ')' scriptBlock elseBlock?;
+filterBlock: 'filter' '(' conditionExpr ')' scriptBlock elseBlock?; // en_preds
 elseBlock: 'else' scriptBlock;
-selectBlock: 'select' '(' selectorList ')' scriptBlock;
+selectBlock: 'select' '(' selectorList ')' scriptBlock; // targets
 actions: mapHolder+ (';' | perEntityHit); // spell action list
 perEntityHit: 'per_entity_hit' scriptBlock;
 
 selectorList: selector ('||' selector)*;
 selector: mapHolder; // spell targets entry
 
-enPredPrefix: 'en' '.';
-condition: enPredPrefix? mapHolder; // single condition
+condition: mapHolder; // single condition
 conditionParen: '(' conditionExpr ')' | condition;
 conditionNot: Not conditionParen | conditionParen;
 conditionAnd: conditionNot ('&&' conditionNot)*;

--- a/src/main/antlr/com/robertx22/mine_and_slash/antlr/Spell.g4
+++ b/src/main/antlr/com/robertx22/mine_and_slash/antlr/Spell.g4
@@ -1,0 +1,89 @@
+grammar Spell;
+
+/*
+ * Parser
+ */
+
+spell: statement+;
+
+statement: propertyStatement | attachedStatement;
+
+// json property values
+propertyBlock: '{' propertyStatement* '}' | propertyStatement;
+propertyStatement: assignment | subobject;
+
+assignment: propertyName '=' propertyValue ';';
+propertyName: Identifier;
+propertyValue: literal | literalArrayValue | objectArrayValue;
+literalArrayValue: '[' (literal (',' literal)* ','?)? ']';
+objectArrayValue: '[' (arrayElement (',' arrayElement)* ','?)? ']';
+arrayElement: '{' propertyStatement* '}';
+
+subobject: subobjectName propertyBlock;
+subobjectName: Identifier;
+
+// spell attached action blocks
+attachedStatement: eventHandler | entity;
+eventHandler: eventName scriptBlock;
+eventName: OnCast | OnTick | OnCastEnd;
+entity: 'entity' entityName scriptBlock;
+entityName: Identifier;
+
+// spell action syntax
+scriptBlock: '{' scriptStatement* '}' | scriptStatement;
+scriptStatement: ifBlock | selectBlock | actions;
+ifBlock: 'if' '(' conditionExpr ')' scriptBlock elseBlock?;
+elseBlock: 'else' scriptBlock;
+selectBlock: 'select' '(' selectorList ')' scriptBlock;
+actions: mapHolder+ (';' | perEntityHit); // spell action list
+perEntityHit: 'per_entity_hit' scriptBlock;
+
+selectorList: selector ('||' selector)*;
+selector: mapHolder; // spell targets entry
+
+enPredPrefix: 'en' '.';
+condition: enPredPrefix? mapHolder; // single condition
+conditionParen: '(' conditionExpr ')' | condition;
+conditionNot: Not conditionParen | conditionParen;
+conditionAnd: conditionNot (And conditionNot)*;
+conditionExpr: conditionAnd;
+
+// corresponds to MapHolder with type and map
+mapHolder: mapHolderType '(' mapHolderArguments? ')';
+mapHolderType: Identifier;
+mapHolderArguments: argumentPositional (',' argumentPositional)* (',' argumentKeyValue)*
+                    | argumentKeyValue (',' argumentKeyValue)*;
+argumentPositional: literal;
+argumentKeyValue: argumentKey '=' argumentValue;
+argumentKey: Identifier;
+argumentValue: literal;
+
+literal: String | Double | Int | bool;
+bool: True | False;
+
+/*
+ * Lexer
+ */
+
+Not: '!';
+And: '&&';
+
+OnCast: 'on_cast';
+OnTick: 'on_tick';
+OnCastEnd: 'on_cast_end';
+
+True: 'true';
+False: 'false';
+
+Double: Number? '.' Number;
+Int: Number;
+fragment Number: '0'..'9'+;
+
+String: '"' ~[\r\n"]* '"';
+
+Identifier: ('a'..'z' | 'A'..'Z' | '0'..'9' | [_$])+;
+
+Comment: '//' ~[\r\n]* [\r]? [\n] -> skip;
+BlockComment: '/*' .*? '*/' -> skip;
+
+WS: [ \t\r\n]+ -> skip;

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/StatMod.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/StatMod.java
@@ -33,7 +33,7 @@ public class StatMod implements ISerializable<StatMod> {
 
     public static StatMod EMPTY = new StatMod();
 
-    private StatMod() {
+    public StatMod() {
 
     }
 

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/SpellCompiler.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/SpellCompiler.java
@@ -34,6 +34,7 @@ import com.robertx22.mine_and_slash.database.data.spells.components.MapHolder;
 import com.robertx22.mine_and_slash.database.data.spells.components.Spell;
 import com.robertx22.mine_and_slash.database.data.spells.components.actions.SpellAction;
 import com.robertx22.mine_and_slash.database.data.spells.components.conditions.EffectCondition;
+import com.robertx22.mine_and_slash.database.data.spells.components.conditions.OrCondition;
 import com.robertx22.mine_and_slash.database.data.spells.components.selectors.BaseTargetSelector;
 import com.robertx22.mine_and_slash.database.data.spells.map_fields.MapField;
 import com.robertx22.mine_and_slash.database.registry.ExileDB;
@@ -450,6 +451,13 @@ public class SpellCompiler {
     }
 
     private void invertConditions(List<ConditionHolder> conditions) {
+        if (conditions.size() == 1) {
+            if (conditions.get(0).map.type == EffectCondition.OR.GUID()) {
+                // to invert an OR, we invert the conditions and turn it into an AND
+                var conditions =
+            }
+        }
+
         for (var condition : conditions) {
             if (condition.map.has(MapField.IS_FALSE) && condition.map.get(MapField.IS_FALSE)) {
                 condition.map.remove(MapField.IS_FALSE);

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/SpellCompiler.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/SpellCompiler.java
@@ -397,7 +397,14 @@ public class SpellCompiler {
         selectorStack.forEach(conditions -> part.targets.addAll(conditions));
 
         ifNotNull(node.perEntityHit(), perEntityHit -> {
+            // don't propagate conditions and selectors to per_entity_hit block
+            var oldConditionStack = conditionStack;
+            var oldSelectorStack = selectorStack;
+            conditionStack = new ArrayDeque();
+            selectorStack = new ArrayDeque();
             part.per_entity_hit = handleScriptBlock(perEntityHit.scriptBlock());
+            conditionStack = oldConditionStack;
+            selectorStack = oldSelectorStack;
         });
 
         return part;

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/SpellCompiler.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/SpellCompiler.java
@@ -1,0 +1,638 @@
+package com.robertx22.mine_and_slash.database.data.spells;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CodePointCharStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.tree.ParseTree;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.robertx22.library_of_exile.main.ExileLog;
+import com.robertx22.library_of_exile.registry.ExileRegistryType;
+import com.robertx22.library_of_exile.registry.JsonExileRegistry;
+import com.robertx22.mine_and_slash.antlr.SpellLexer;
+import com.robertx22.mine_and_slash.antlr.SpellParser;
+import com.robertx22.mine_and_slash.antlr.SpellParser.*;
+import com.robertx22.mine_and_slash.database.data.spells.components.BaseFieldNeeder;
+import com.robertx22.mine_and_slash.database.data.spells.components.ComponentPart;
+import com.robertx22.mine_and_slash.database.data.spells.components.MapHolder;
+import com.robertx22.mine_and_slash.database.data.spells.components.Spell;
+import com.robertx22.mine_and_slash.database.data.spells.components.actions.SpellAction;
+import com.robertx22.mine_and_slash.database.data.spells.components.conditions.EffectCondition;
+import com.robertx22.mine_and_slash.database.data.spells.components.selectors.BaseTargetSelector;
+import com.robertx22.mine_and_slash.database.data.spells.map_fields.MapField;
+import com.robertx22.mine_and_slash.database.registry.ExileDB;
+
+import net.minecraft.resources.FileToIdConverter;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+
+public class SpellCompiler {
+    private static enum MapHolderType {
+        ACTION(SpellAction.MAP),
+        CONDITION(EffectCondition.MAP),
+        SELECTOR(BaseTargetSelector.MAP);
+
+        private final HashMap map;
+
+        private MapHolderType(HashMap map) {
+            this.map = map;
+        }
+    }
+
+    private static abstract class CompilerError extends Exception {
+        public int startLine;
+        public int startChar;
+        public int endLine;
+        public int endChar;
+
+        public CompilerError(ParserRuleContext context, String details) {
+            super(details);
+            startLine = context.start.getLine();
+            startChar = context.start.getCharPositionInLine();
+            endLine = context.stop.getLine();
+            endChar = context.stop.getCharPositionInLine();
+        }
+        @Override
+        public String toString() {
+            return String.format("%d,%d: %s: %s", startLine, startChar, errorType(), getMessage());
+        }
+        public abstract String errorType();
+    }
+
+    private static class PropertyNameError extends CompilerError {
+        Object accessObject;
+        public PropertyNameError(ParserRuleContext context, Object accessObject, String details) {
+            super(context, details);
+            this.accessObject = accessObject;
+        }
+        @Override public String errorType() { return String.format("No such property in %s", accessObject.getClass().getSimpleName()); }
+    }
+
+    private static class PropertyTypeError extends CompilerError {
+        Object accessObject;
+        public PropertyTypeError(ParserRuleContext context, Object accessObject, String details) {
+            super(context, details);
+            this.accessObject = accessObject;
+        }
+        @Override public String errorType() { return String.format("Accessed property as wrong type in %s", accessObject.getClass().getSimpleName()); }
+    }
+
+    private static class PropertyEnumError extends CompilerError {
+        Object accessObject;
+        public PropertyEnumError(ParserRuleContext context, Object accessObject, String details) {
+            super(context, details);
+            this.accessObject = accessObject;
+        }
+        @Override public String errorType() { return String.format("Passed invalid value for enum in %s", accessObject.getClass().getSimpleName()); }
+    }
+
+    private static class MapHolderNameError extends CompilerError {
+        String type;
+        public MapHolderNameError(ParserRuleContext context, String name, MapHolderType type) {
+            super(context, name);
+            this.type = type.toString().toLowerCase();
+        }
+        @Override public String errorType() { return String.format("No such %s", type); }
+    }
+
+    private static class SyntaxError extends CompilerError {
+        public SyntaxError(ParserRuleContext context, String details) { super(context, details); }
+        @Override public String errorType() { return "Syntax error"; }
+    }
+
+    private static class ValueWrapper {
+        Object value;
+    };
+
+    private static class ConditionHolder {
+        private static enum Type {
+            IF,
+            EN_PRED
+        };
+        MapHolder map;
+        Type type;
+    };
+
+    public static void compileSpells(ExileRegistryType type, ResourceManager manager, String name, Gson gson, Map<ResourceLocation, JsonElement> output) {
+        var converter = new FileToIdConverter(name, ".spell");
+
+        ExileLog.get().log("Parsing spell sources");
+
+        converter.listMatchingResources(manager).forEach((location, resource) -> {
+            var fileId = converter.fileToId(location);
+
+            ExileLog.get().log("Parsing spell source {}", location.getPath());
+
+            BufferedReader reader;
+            CodePointCharStream charStream;
+
+            try {
+                reader = resource.openAsReader();
+                charStream = CharStreams.fromReader(reader);
+            } catch (IOException exception) {
+                ExileLog.get().warn("IOException while reading " + location.toString() + "\n" + exception.toString());
+                JsonExileRegistry.addToErroredJsons(type, fileId);
+                return;
+            }
+
+            var compiler = new SpellCompiler(charStream, fileId);
+            JsonElement spellJson;
+
+            try {
+                spellJson = compiler.compile();
+            } catch (CompilerError error) {
+                ExileLog.get().warn("{}:{}", location.toString(), error.toString());
+                JsonExileRegistry.addToErroredJsons(type, fileId);
+                return;
+            } finally {
+                try {
+                    reader.close();
+                } catch (IOException exception) {
+                    ExileLog.get().warn("{}: IOException while closing\n{}", location.toString(), exception.toString());
+                    JsonExileRegistry.addToErroredJsons(type, fileId);
+                    return;
+                }
+            }
+
+            output.put(fileId, spellJson);
+        });
+    }
+
+    private interface IfNotNullFunction<T extends ParseTree> {
+        void accept(T node) throws CompilerError;
+    }
+
+    private interface ElseFunction {
+        void run() throws CompilerError;
+    }
+
+    private static abstract class ElseIfNotNull {
+        public abstract <T extends ParseTree> ElseIfNotNull elseIfNotNull(T node, IfNotNullFunction<T> consumer) throws CompilerError;
+        public abstract <T extends ParseTree> void elseDo(ElseFunction runnable) throws CompilerError;
+    }
+
+    private static class TrueElseIfNotNull extends ElseIfNotNull {
+        @Override
+        public <T extends ParseTree> ElseIfNotNull elseIfNotNull(T node, IfNotNullFunction<T> consumer) throws CompilerError {
+            return new TrueElseIfNotNull();
+        }
+        @Override
+        public <T extends ParseTree> void elseDo(ElseFunction runnable) throws CompilerError {
+        }
+    }
+
+    private static class FalseElseIfNotNull extends ElseIfNotNull {
+        @Override
+        public <T extends ParseTree> ElseIfNotNull elseIfNotNull(T node, IfNotNullFunction<T> consumer) throws CompilerError {
+            return ifNotNull(node, consumer);
+        }
+        @Override
+        public <T extends ParseTree> void elseDo(ElseFunction runnable) throws CompilerError {
+            runnable.run();
+        }
+    }
+
+    private static <T extends ParseTree> ElseIfNotNull ifNotNull(T node, IfNotNullFunction<T> consumer) throws CompilerError {
+        if (node != null) {
+            consumer.accept(node);
+            return new TrueElseIfNotNull();
+        } else {
+            return new FalseElseIfNotNull();
+        }
+    }
+
+    private SpellLexer lexer;
+    private TokenStream tokenStream;
+    private SpellParser parser;
+    private ResourceLocation fileId;
+    private Spell spell;
+
+    // each nested json subobject we're accessing
+    private Deque<Object> objectAccessStack = new ArrayDeque<>();
+
+    // nested conditional blocks
+    private Deque<List<ConditionHolder>> conditionStack = new ArrayDeque<>();
+
+    // nested select blocks
+    private Deque<List<MapHolder>> selectorStack = new ArrayDeque<>();
+
+    private SpellCompiler(CodePointCharStream charStream, ResourceLocation fileId) {
+        this.lexer = new SpellLexer(charStream);
+        this.tokenStream = new CommonTokenStream(lexer);
+        this.parser = new SpellParser(tokenStream);
+        this.fileId = fileId;
+    }
+
+    private JsonElement compile() throws CompilerError {
+        spell = new Spell();
+        spell.identifier = fileId.getPath();
+        objectAccessStack.push(spell);
+
+        var root = parser.spell();
+
+        for (var statement : root.statement()) {
+            ifNotNull(statement.propertyStatement(), propertyStatement -> {
+                handlePropertyStatement(propertyStatement);
+            }).elseIfNotNull(statement.attachedStatement(), attachedStatement -> {
+                handleAttachedStatement(attachedStatement);
+            });
+        }
+
+        return spell.toJson();
+    }
+
+    private void handlePropertyBlock(PropertyBlockContext node) throws CompilerError {
+        for (var statement : node.propertyStatement()) {
+            handlePropertyStatement(statement);
+        }
+    }
+
+    private void handlePropertyStatement(PropertyStatementContext node) throws CompilerError {
+        ifNotNull(node.subobject(), subobject -> {
+            handleSubobject(subobject);
+        }).elseIfNotNull(node.assignment(), assignment -> {
+            handleAssignment(assignment);
+        });
+    }
+
+    private void handleAssignment(AssignmentContext node) throws CompilerError {
+        var propertyName = node.propertyName().getText();
+
+        ifNotNull(node.propertyValue().literalArrayValue(), literalArrayValue -> {
+            // handle arrays of primitives
+            var elements = new ArrayList();
+            for (var literal : literalArrayValue.literal()) {
+                elements.add(handleLiteral(literal));
+            }
+            writeTopObjectFieldCollection(node, propertyName, elements);
+        }).elseIfNotNull(node.propertyValue().objectArrayValue(), objectArrayValue -> {
+            // handle arrays of objects
+            writeTopObjectFieldObjectCollection(node, propertyName, elementConstructor -> {
+                var elements = new ArrayList();
+
+                for (var elementBlock : objectArrayValue.arrayElement()) {
+                    // descend into each array element
+                    var element = elementConstructor.newInstance();
+                    objectAccessStack.push(element);
+                    for (var statement : elementBlock.propertyStatement()) {
+                        handlePropertyStatement(statement);
+                    }
+                    objectAccessStack.pop();
+                    elements.add(element);
+                }
+
+                return elements;
+            });
+        }).elseDo(() -> {
+            // handle primitive values
+            var propertyValue = handleLiteral(node.propertyValue().literal());
+            writeTopObjectField(node, propertyName, propertyValue);
+        });
+    }
+
+    private Object handleLiteral(LiteralContext node) throws CompilerError {
+        var value = new ValueWrapper();
+
+        ifNotNull(node.String(), asString -> {
+            var text = asString.getText(); // includes quotes
+            value.value = text.substring(1, text.length() - 1);
+        }).elseIfNotNull(node.Double(), asDouble -> {
+            value.value = Double.parseDouble(asDouble.getText());
+        }).elseIfNotNull(node.Int(), asInt -> {
+            value.value = Integer.parseInt(asInt.getText());
+        }).elseIfNotNull(node.bool(), asBool -> {
+            value.value = asBool.True() != null;
+        });
+
+        return value.value;
+    }
+
+    private void handleSubobject(SubobjectContext node) throws CompilerError {
+        var name = node.subobjectName().getText();
+        objectAccessStack.push(readTopObjectField(node, name));
+        handlePropertyBlock(node.propertyBlock());
+        objectAccessStack.pop();
+    }
+
+    private void handleAttachedStatement(AttachedStatementContext node) throws CompilerError {
+        ifNotNull(node.eventHandler(), (eventHandler) -> {
+            handleEventHandler(eventHandler);
+        }).elseDo(() -> {
+            handleEntity(node.entity());
+        });
+    }
+
+    private void handleEventHandler(EventHandlerContext node) throws CompilerError {
+        var parts = handleScriptBlock(node.scriptBlock());
+
+        if (node.eventName().OnCast() != null) {
+            spell.attached.on_cast.addAll(parts);
+        } else if (node.eventName().OnTick() != null) {
+            //spell.attached.on_tick.addAll(parts);
+        } else if (node.eventName().OnCastEnd() != null) {
+            //spell.attached.on_cast_end.addAll(parts);
+        }
+    }
+
+    private void handleEntity(EntityContext node) throws CompilerError {
+        var parts = handleScriptBlock(node.scriptBlock());
+        var name = node.entityName().toString();
+        spell.attached.entity_components.put(name, parts);
+    }
+
+    // returns list of spell parts
+    private List<ComponentPart> handleScriptBlock(ScriptBlockContext node) throws CompilerError {
+        var parts = new ArrayList<ComponentPart>();
+
+        for (var statement : node.scriptStatement()) {
+            ifNotNull(statement.ifBlock(), ifBlock -> {
+                parts.addAll(handleIfBlock(ifBlock));
+            }).elseIfNotNull(statement.selectBlock(), selectBlock -> {
+                parts.addAll(handleSelectBlock(selectBlock));
+            }).elseIfNotNull(statement.actions(), actions -> {
+                parts.add(handleActions(actions));
+            });
+        }
+
+        return parts;
+    }
+
+    // action list / spell part
+    private ComponentPart handleActions(ActionsContext node) throws CompilerError {
+        var part = new ComponentPart();
+
+        for (var action : node.mapHolder()) {
+            part.acts.add(handleAction(action));
+        }
+
+        for (var conditions : conditionStack) {
+            for (var condition : conditions) {
+                switch (condition.type) {
+                case IF:
+                    part.ifs.add(condition.map);
+                    break;
+                case EN_PRED:
+                    part.en_preds.add(condition.map);
+                    break;
+                }
+            }
+        }
+
+        selectorStack.forEach(conditions -> part.targets.addAll(conditions));
+
+        ifNotNull(node.perEntityHit(), perEntityHit -> {
+            part.per_entity_hit = handleScriptBlock(perEntityHit.scriptBlock());
+        });
+
+        return part;
+    }
+
+    // returns list of spell parts
+    private List<ComponentPart> handleIfBlock(IfBlockContext node) throws CompilerError {
+        var conditions = handleConditionExpr(node.conditionExpr());
+        conditionStack.push(conditions);
+
+        var parts = handleScriptBlock(node.scriptBlock());
+
+        ifNotNull(node.elseBlock(), elseBlock -> {
+            invertConditions(conditions);
+            parts.addAll(handleScriptBlock(elseBlock.scriptBlock()));
+        });
+
+        conditionStack.pop();
+        return parts;
+    }
+
+    // returns list of conditions
+    private List<ConditionHolder> handleConditionExpr(ConditionExprContext node) throws CompilerError {
+        return handleConditionAnd(node.conditionAnd());
+    }
+
+    // returns list of conditions
+    private List<ConditionHolder> handleConditionAnd(ConditionAndContext node) throws CompilerError {
+        var conditions = new ArrayList<ConditionHolder>();
+        for (var child : node.conditionNot()) {
+            conditions.addAll(handleConditionNot(child));
+        }
+        return conditions;
+    }
+
+    // returns list of conditions
+    private List<ConditionHolder> handleConditionNot(ConditionNotContext node) throws CompilerError {
+        var conditions = handleConditionParen(node.conditionParen());
+        if (node.Not() != null) {
+            invertConditions(conditions);
+        }
+        return conditions;
+    }
+
+    private void invertConditions(List<ConditionHolder> conditions) {
+        for (var condition : conditions) {
+            if (condition.map.has(MapField.IS_FALSE) && condition.map.get(MapField.IS_FALSE)) {
+                condition.map.remove(MapField.IS_FALSE);
+            } else {
+                condition.map.put(MapField.IS_FALSE, true);
+            }
+        }
+    }
+
+    // returns list of conditions
+    private List<ConditionHolder> handleConditionParen(ConditionParenContext node) throws CompilerError {
+        if (node.condition() != null) {
+            return List.of(handleCondition(node.condition()));
+        } else {
+            return handleConditionExpr(node.conditionExpr());
+        }
+    }
+
+    // returns list of spell parts
+    private List<ComponentPart> handleSelectBlock(SelectBlockContext node) throws CompilerError {
+        var selectors = new ArrayList<MapHolder>();
+
+        for (var selector : node.selectorList().selector()) {
+            selectors.add(handleSelector(selector));
+        }
+
+        selectorStack.push(selectors);
+        var parts = handleScriptBlock(node.scriptBlock());
+        selectorStack.pop();
+
+        return parts;
+    }
+
+    // returns single action
+    private MapHolder handleAction(MapHolderContext node) throws CompilerError {
+        return handleMapHolder(node, MapHolderType.ACTION);
+    }
+
+    // returns single condition
+    private ConditionHolder handleCondition(ConditionContext node) throws CompilerError {
+        var condition = new ConditionHolder();
+        condition.map = handleMapHolder(node.mapHolder(), MapHolderType.CONDITION);
+        condition.type = node.enPredPrefix() != null ? ConditionHolder.Type.EN_PRED : ConditionHolder.Type.IF;
+        return condition;
+    }
+
+    // returns single selector
+    private MapHolder handleSelector(SelectorContext node) throws CompilerError {
+        return handleMapHolder(node.mapHolder(), MapHolderType.SELECTOR);
+    }
+
+    private MapHolder handleMapHolder(MapHolderContext node, MapHolderType type) throws CompilerError {
+        var map = new MapHolder();
+        map.type = node.mapHolderType().getText();
+
+        if (!type.map.containsKey(map.type)) {
+            throw new MapHolderNameError(node, map.type, type);
+        }
+
+        var args = node.mapHolderArguments();
+        var typeObject = (BaseFieldNeeder) type.map.get(map.type);
+        var requiredArgCount = typeObject.requiredPieces.size();
+        var positionalArgCount = args != null ? args.argumentPositional().size() : 0;
+
+        if (positionalArgCount > requiredArgCount) {
+            throw new SyntaxError(
+                node, String.format("Expected at most %d positional arguments to '%s', got %d",
+                    requiredArgCount, map.type, positionalArgCount));
+        }
+
+        if (args != null) {
+            for (var i = 0; i < positionalArgCount; i++) {
+                var positionalArg = args.argumentPositional(i);
+                var field = typeObject.requiredPieces.get(i);
+                var value = handleLiteral(positionalArg.literal());
+                addToMapHolder(map, field, value);
+            }
+
+            for (var keywordArg : args.argumentKeyValue()) {
+                var fieldName = keywordArg.argumentKey().getText();
+
+                if (!MapField.MAP.containsKey(fieldName)) {
+                    throw new SyntaxError(node, String.format("Unknown argument name '%s'", fieldName));
+                }
+
+                var field = MapField.MAP.get(fieldName);
+                var value = handleLiteral(keywordArg.argumentValue().literal());
+                addToMapHolder(map, field, value);
+            }
+        }
+
+        for (var requiredField : typeObject.requiredPieces) {
+            if (!map.has(requiredField)) {
+                throw new SyntaxError(node, String.format("Missing required field '%s'", requiredField.GUID()));
+            }
+        }
+
+        return map;
+    }
+
+    private void addToMapHolder(MapHolder map, MapField field, Object value) {
+        if (field == MapField.VALUE_CALCULATION && value instanceof String valueCalcName) {
+            map.put(field, ExileDB.ValueCalculations().get(valueCalcName));
+        } else {
+            map.put(field, value);
+        }
+    }
+
+    private Object getTopObject() {
+        return objectAccessStack.getFirst();
+    }
+
+    private Field getObjectField(ParserRuleContext node, Object object, String name) throws CompilerError {
+        Field field;
+        try {
+            field = object.getClass().getDeclaredField(name);
+        } catch (NoSuchFieldException e) {
+            throw new PropertyNameError(node, object, e.getMessage());
+        }
+
+        field.setAccessible(true);
+        return field;
+    }
+
+    private Object readTopObjectField(ParserRuleContext context, String name) throws CompilerError {
+        var topObject = getTopObject();
+        var field = getObjectField(context, topObject, name);
+        try {
+            return field.get(topObject);
+        } catch (IllegalAccessException e) {
+            throw new PropertyTypeError(context, topObject, e.getMessage());
+        }
+    }
+
+    private void writeTopObjectField(ParserRuleContext context, String name, Object value) throws CompilerError {
+        var topObject = getTopObject();
+        var field = getObjectField(context, topObject, name);
+        var fieldType = field.getType();
+
+        if (fieldType.equals(float.class) && value instanceof Double doubleValue) {
+            // allow assigning double literals to float fields
+            value = (float) (double) doubleValue;
+        } else if (fieldType.isEnum() && value instanceof String enumValue) {
+            // allow assigning string literals to enum fields
+            try {
+                value = Enum.valueOf((Class) fieldType, enumValue);
+            } catch (Exception e) {
+                throw new PropertyEnumError(context, topObject, e.getMessage());
+            }
+        }
+
+        try {
+            field.set(topObject, value);
+        } catch (Exception e) {
+            throw new PropertyTypeError(context, topObject, e.getMessage());
+        }
+    }
+
+    private void writeTopObjectFieldCollection(ParserRuleContext context, String name, Collection value) throws CompilerError {
+        var topObject = getTopObject();
+        var field = getObjectField(context, topObject, name);
+        try {
+            var collection = (Collection) field.get(topObject);
+            collection.clear();
+            collection.addAll(value);
+        } catch (Exception e) {
+            throw new PropertyTypeError(context, topObject, e.getMessage());
+        }
+    }
+
+    private interface CollectionProducerFunction {
+        Collection produce(Constructor elementConstructor) throws Exception;
+    }
+
+    // for writing to lists of objects, allows default constructing elements
+    private void writeTopObjectFieldObjectCollection(ParserRuleContext context, String name, CollectionProducerFunction producer) throws CompilerError {
+        var topObject = getTopObject();
+        var field = getObjectField(context, topObject, name);
+        try {
+            var fieldGenericType = (ParameterizedType) field.getGenericType();
+            var elementType = (Class) fieldGenericType.getActualTypeArguments()[0];
+            var constructor = elementType.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            var collection = (Collection) field.get(topObject);
+            collection.clear();
+            collection.addAll(producer.produce(elementType.getConstructor()));
+        } catch (CompilerError e) {
+            throw e;
+        } catch (Exception e) {
+            throw new PropertyTypeError(context, topObject, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/BaseFieldNeeder.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/BaseFieldNeeder.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public abstract class BaseFieldNeeder implements IGUID {
 
-    List<MapField> requiredPieces;
+    public List<MapField> requiredPieces;
 
     public BaseFieldNeeder(List<MapField> requiredPieces) {
         this.requiredPieces = requiredPieces;

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/ComponentPart.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/ComponentPart.java
@@ -18,7 +18,7 @@ public class ComponentPart {
     public List<MapHolder> ifs = new ArrayList<>();
     public List<MapHolder> en_preds = new ArrayList<>();
 
-    List<ComponentPart> per_entity_hit = null;
+    public List<ComponentPart> per_entity_hit = null;
 
     public ComponentPart addPerEntityHit(ComponentPart add) {
 
@@ -72,7 +72,7 @@ public class ComponentPart {
         } else {
             throw new NullPointerException("Activation not found"); // ... why did i do it like this
         }
-        
+
         return this;
     }
 

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/MapHolder.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/MapHolder.java
@@ -62,6 +62,10 @@ public class MapHolder {
         return (T) map.get(field.GUID());
     }
 
+    public <T> void remove(MapField<T> field) {
+        this.map.remove(field);
+    }
+
     public ExileEffect getExileEffect() {
         return ExileDB.ExileEffects().get(get(EXILE_POTION_ID));
     }

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/vanity/ParticleInRadiusAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/vanity/ParticleInRadiusAction.java
@@ -41,14 +41,16 @@ public class ParticleInRadiusAction extends SpellAction {
             int amount = data.get(PARTICLE_COUNT).intValue();
             amount *= ctx.calculatedSpellData.data.getNumber(EventData.AREA_MULTI, 1F).number;
 
-         
-            ParticleMotion motion = null;
 
-            try {
-                motion = ParticleMotion.valueOf(data.get(MOTION));
-            } catch (IllegalArgumentException e) {
-                e.printStackTrace();
-                motion = ParticleMotion.None;
+            ParticleMotion motion = ParticleMotion.None;
+
+            if (data.has(MOTION)) {
+                try {
+                    motion = ParticleMotion.valueOf(data.get(MOTION));
+                } catch (IllegalArgumentException e) {
+                    e.printStackTrace();
+                    motion = ParticleMotion.None;
+                }
             }
 
             float yrand = data.getOrDefault(Y_RANDOM, 0D).floatValue();

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/vanity/SoundAction.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/actions/vanity/SoundAction.java
@@ -16,14 +16,14 @@ import static com.robertx22.mine_and_slash.database.data.spells.map_fields.MapFi
 public class SoundAction extends SpellAction {
 
     public SoundAction() {
-        super(Arrays.asList(SOUND, PITCH, VOLUME));
+        super(Arrays.asList(SOUND, VOLUME));
     }
 
     @Override
     public void tryActivate(Collection<LivingEntity> targets, SpellCtx ctx, MapHolder data) {
         if (!ctx.world.isClientSide) {
             try {
-                float pitch = data.get(PITCH).floatValue();
+                float pitch = data.getOrDefault(PITCH, 1.0).floatValue();
                 float volume = data.get(VOLUME).floatValue();
                 SoundEvent sound = data.getSound();
 

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/conditions/EffectCondition.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/conditions/EffectCondition.java
@@ -33,6 +33,7 @@ public abstract class EffectCondition extends BaseFieldNeeder implements IGUID {
     public static HasMnsEffectCondition HAS_MNS_EFFECT;
     public static CasterHasMnsEffectCondition CASTER_HAS_MNS_EFFECT;
 
+    public static OrCondition OR;
 
     public abstract boolean canActivate(SpellCtx ctx, MapHolder data);
 
@@ -47,6 +48,10 @@ public abstract class EffectCondition extends BaseFieldNeeder implements IGUID {
         return can;
     }
 
+    public final static boolean conditionPasses(MapHolder part, SpellCtx ctx) {
+        return EffectCondition.MAP.get(part.type).can(ctx, part);
+    }
+
     public final static boolean conditionsPass(List<MapHolder> ifs, SpellCtx ctx) {
 
         boolean did = true;
@@ -54,9 +59,7 @@ public abstract class EffectCondition extends BaseFieldNeeder implements IGUID {
 
         for (MapHolder part : ifs) {
 
-            EffectCondition condition = EffectCondition.MAP.get(part.type);
-
-            boolean passed = condition.can(ctx, part);
+            boolean passed = conditionPasses(part, ctx);
 
             boolean isOptional = part.getOrDefault(MapField.OPTIONAL, false);
 
@@ -74,7 +77,6 @@ public abstract class EffectCondition extends BaseFieldNeeder implements IGUID {
 
         return did;
     }
-
 
     public static HashMap<String, EffectCondition> MAP = new HashMap<>();
 
@@ -102,6 +104,7 @@ public abstract class EffectCondition extends BaseFieldNeeder implements IGUID {
         CASTER_HAS_STAT = of(new CasterHasStatCondition());
         ON_ATTACKED = of(new OnAttackedCondition());
 
+        OR = of(new OrCondition());
     }
 }
 

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/conditions/OrCondition.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/conditions/OrCondition.java
@@ -1,0 +1,32 @@
+package com.robertx22.mine_and_slash.database.data.spells.components.conditions;
+
+import com.robertx22.mine_and_slash.database.data.spells.components.MapHolder;
+import com.robertx22.mine_and_slash.database.data.spells.map_fields.MapField;
+import com.robertx22.mine_and_slash.database.data.spells.spell_classes.SpellCtx;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class OrCondition extends EffectCondition {
+
+    public OrCondition() {
+        super(Arrays.asList(MapField.MAPS));
+    }
+
+    @Override
+    public boolean canActivate(SpellCtx ctx, MapHolder data) {
+        return data.get(MapField.MAPS).stream().anyMatch(condition -> EffectCondition.conditionPasses(condition, ctx));
+    }
+
+    public MapHolder create(List<MapHolder> conditions) {
+        MapHolder d = new MapHolder();
+        d.type = GUID();
+        d.put(MapField.MAPS, conditions);
+        return d;
+    }
+
+    @Override
+    public String GUID() {
+        return "or";
+    }
+}

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/selectors/AoeSelector.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/components/selectors/AoeSelector.java
@@ -22,7 +22,7 @@ import static com.robertx22.mine_and_slash.database.data.spells.map_fields.MapFi
 public class AoeSelector extends BaseTargetSelector {
 
     public AoeSelector() {
-        super(Arrays.asList(RADIUS, SELECTION_TYPE, ENTITY_PREDICATE));
+        super(Arrays.asList(RADIUS, ENTITY_PREDICATE));
     }
 
     @Override

--- a/src/main/java/com/robertx22/mine_and_slash/database/data/spells/map_fields/MapField.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/data/spells/map_fields/MapField.java
@@ -1,6 +1,7 @@
 package com.robertx22.mine_and_slash.database.data.spells.map_fields;
 
 import com.robertx22.library_of_exile.registry.IGUID;
+import com.robertx22.mine_and_slash.database.data.spells.components.MapHolder;
 import com.robertx22.mine_and_slash.database.data.value_calc.ValueCalculation;
 
 import java.util.HashMap;
@@ -110,6 +111,8 @@ public class MapField<T> implements IGUID {
     public static MapField<List<String>> ENTITY_PREDICATES = make("entity_predicates");
 
     public static MapField<ValueCalculation> VALUE_CALCULATION = make("value_calculation");
+
+    public static MapField<List<MapHolder>> MAPS = make("maps");
 
     public MapField(String id) {
         this.id = id;

--- a/src/main/java/com/robertx22/mine_and_slash/database/registry/ExileRegistryTypes.java
+++ b/src/main/java/com/robertx22/mine_and_slash/database/registry/ExileRegistryTypes.java
@@ -1,5 +1,9 @@
 package com.robertx22.mine_and_slash.database.registry;
 
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.robertx22.addons.orbs_of_crafting.currency.reworked.addon.ExtendedOrb;
 import com.robertx22.library_of_exile.registry.ExileRegistryType;
 import com.robertx22.library_of_exile.registry.SyncTime;
@@ -30,6 +34,7 @@ import com.robertx22.mine_and_slash.database.data.rarities.MobRarity;
 import com.robertx22.mine_and_slash.database.data.runes.Rune;
 import com.robertx22.mine_and_slash.database.data.runewords.RuneWord;
 import com.robertx22.mine_and_slash.database.data.spell_school.SpellSchool;
+import com.robertx22.mine_and_slash.database.data.spells.SpellCompiler;
 import com.robertx22.mine_and_slash.database.data.spells.components.Spell;
 import com.robertx22.mine_and_slash.database.data.stat_compat.StatCompat;
 import com.robertx22.mine_and_slash.database.data.stats.datapacks.base.BaseDatapackStat;
@@ -44,6 +49,8 @@ import com.robertx22.mine_and_slash.uncommon.effectdatas.rework.action.StatEffec
 import com.robertx22.mine_and_slash.uncommon.effectdatas.rework.condition.StatCondition;
 import com.robertx22.mine_and_slash.uncommon.enumclasses.WeaponTypes;
 import net.minecraft.ChatFormatting;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
 
 public class ExileRegistryTypes {
 
@@ -70,7 +77,14 @@ public class ExileRegistryTypes {
     public static ExileRegistryType RUNEWORDS = ExileRegistryType.register(SlashRef.MODID, "runeword", 12, RuneWord.SERIALIZER, SyncTime.ON_LOGIN);
     public static ExileRegistryType DIMENSION_CONFIGS = ExileRegistryType.register(SlashRef.MODID, "dimension", 13, DimensionConfig.EMPTY, SyncTime.ON_LOGIN);
     public static ExileRegistryType ENTITY_CONFIGS = ExileRegistryType.register(SlashRef.MODID, "entity", 14, Serializers.ENTITY_CONFIG_SER, SyncTime.NEVER);
-    public static ExileRegistryType SPELL = ExileRegistryType.register(SlashRef.MODID, "spells", 17, Spell.SERIALIZER, SyncTime.ON_LOGIN);
+
+    public static ExileRegistryType SPELL = ExileRegistryType.register(new ExileRegistryType(SlashRef.MODID, "spells", 17, Spell.SERIALIZER, SyncTime.ON_LOGIN) {
+        @Override
+        public void injectResources(ResourceManager manager, String name, Gson gson, Map<ResourceLocation, JsonElement> output) {
+            SpellCompiler.compileSpells(this, manager, name, gson, output);
+        }
+    });
+
     public static ExileRegistryType PERK = ExileRegistryType.register(SlashRef.MODID, "perk", 18, Perk.SERIALIZER, SyncTime.ON_LOGIN);
     public static ExileRegistryType TALENT_TREE = ExileRegistryType.register(SlashRef.MODID, "talent_tree", 19, TalentTree.SERIALIZER, SyncTime.ON_LOGIN);
     public static ExileRegistryType BASE_STATS = ExileRegistryType.register(SlashRef.MODID, "base_stats", 22, BaseStatsConfig.SERIALIZER, SyncTime.ON_LOGIN);


### PR DESCRIPTION
The new language can be used by using a .spell extension instead of .json
Example rewrite of Gong Strike:
```c
identifier = "gong_strike";
loc_name = "Gong Strike";
max_lvl = 16;
min_lvl = 1;
statsForSkillGem = [
    { type = "FLAT"; min = 15.0; max = 30.0; stat = "endurance_charge_on_hit"; }
];

cast_finish_animation id = "spell_taunt";

config {
    tags tags = ["weapon_skill", "damage", "melee", "physical"];
    castingWeapon = "MELEE_WEAPON";
    style = "str";
    cast_time_ticks = 0;
    cooldown_ticks = 40;
    ene_cost { min = 6.0; max = 8.0; }
    mana_cost { min = 1.0; max = 2.0; }
    swing_arm = false;
}

on_cast {
    // note the omitted semicolons; these are combined into one spell component part
    sound("roe_sfx:spell_gongstrike", 1.0)
    sound("roe_sfx:spell_hit_heavy", 1.0)
    particles_in_radius("minecraft:cloud", radius=2.0, particle_count=300.0, shape="CIRCLE_2D", height=0.5, y_rand=0.1)
    particles_in_radius("minecraft:explosion", radius=2.0, particle_count=5.0, shape="CIRCLE_2D", height=0.5, y_rand=0.1);

    if (caster_has_mns_effect("fighter_stance")) {
        select (in_front(5.0, 2.5, "enemies")) {
            damage("Physical", "gong_strike_fighter", disable_knockback=true);
        }
    } else if (caster_has_mns_effect("defender_stance")) {
        select (in_front(4.0, 2.0, "enemies")) {
            damage("Physical", "gong_strike", disable_knockback=true)
            exile_effect("stun", 1.0, "GIVE_STACKS", 10.0);
        }
    } else {
        select (in_front(4.0, 2.0, "enemies")) {
            damage("Physical", "gong_strike_plain", disable_knockback=true);
        }
    }
}
```
Significant features not showcased are combining conditions with `&&`, inverting conditions (`is_false` shouldn't be used directly), adding `en_preds`, and `per_entity_hit`:
```c
if (caster_has_mns_effect("defender_stance") && !en.has_mns_effect("slow")) {
    damage("Physical", "primary_hit", disable_knockback=true) per_entity_hit {
        select (aoe(3.0, "enemies")) damage("Physical", "secondary_hit", disable_knockback=true)
    }
}
```
Selectors can also be combined with `||`:
```c
select (in_front(5.0, 2.5, "enemies") || aoe(3.0, "enemies")) {
    /* ... */
}
```
Oh yeah and entities:
```c
entity my_sick_entity {
    if (x_ticks_condition(5.0)) {
        // idk do somethin
    }
}
```
Requires https://github.com/mahjerion/Library-of-Exile-Rework/pull/8

KNOWN ISSUE: constructs like `if (!(cond1() && cond2()))` or `if (cond1() && cond2()) { } else { }` don't work properly because mns doesn't yet support OR in conditions, which this is equivalent to